### PR TITLE
add/room_list

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.Notification {
+  @apply text-center;
+}
+
+.Notification .notice {
+  @apply text-matcha text-center;
+}
+
+.Notification .alert {
+  @apply text-brown text-center;
+}

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,0 +1,32 @@
+class RoomsController < ApplicationController
+  def index
+    @room = Room.new
+    @rooms = current_user.rooms.includes(:user).order(created_at: :desc)
+  end
+
+  def create
+    if current_user.rooms.count >= 5
+      flash[:alert] = "1人あたり5部屋まで登録できます。"
+      redirect_to rooms_path and return
+    end
+
+    @room= current_user.rooms.new(room_params)
+    respond_to do |format|
+      if @room.save
+        format.html { redirect_to @room, notice: "部屋を作成しました" }
+      else
+        format.html { render :index, alert: "部屋を作成できませんでした", status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def show
+    @room = Room.find(params[:id])
+  end
+
+  private
+
+  def room_params
+    params.require(:room).permit(:name)
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -21,7 +21,7 @@ class Users::SessionsController < Devise::SessionsController
   protected
 
   def after_sign_in_path_for(resource)
-    root_path
+    rooms_path
   end
 
   def after_sign_out_path_for(resource_or_scope)

--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -1,0 +1,2 @@
+module RoomsHelper
+end

--- a/app/models/exchange_diary.rb
+++ b/app/models/exchange_diary.rb
@@ -1,5 +1,5 @@
 class ExchangeDiary < ApplicationRecord
   belongs_to :user
 
-  validates :body, presence: true
+  validates :body, presence: true, length: { maximum: 65_535 }
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,0 +1,5 @@
+class Room < ApplicationRecord
+  belongs_to :user
+
+  validates :name, presence: true, length: { maximum: 30 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,13 @@ class User < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   has_many :exchange_diaries
+  has_many :rooms
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  def own?(object)
+    id == object&.user_id
+  end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -12,7 +12,7 @@
           <%= f.label :password, class: "block text-sm font-medium text-green-400" %>
           <%= f.password_field :password, class: "mt-1 mb-6 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-green-400 focus:border-green-600 text-green-400" %>
         </div>
-        <%= f.submit 'ログイン', class: "w-full mb-6 bg-green-400 hover:bg-green-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition" %>
+        <%= f.submit 'ログインして帰宅', class: "w-full mb-6 bg-green-400 hover:bg-green-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition" %>
         <% end %>
         <%= link_to '新規登録はこちら', new_user_registration_path, class: "text-green-600" %>
     </div>

--- a/app/views/exchange_diaries/_form.html.erb
+++ b/app/views/exchange_diaries/_form.html.erb
@@ -1,4 +1,13 @@
 <%= form_with model: @exchange_diary, url: exchange_diaries_path, remote: true do |f| %>
+  <% if @exchange_diary.errors.any? %>
+    <div class= "text-bold text-brown">
+        <% @exchange_diary.errors.full_messages.each do |message| %>
+          <ul>
+            <li><%= message %></li>
+          </ul>
+        <% end %>
+    </div>
+  <% end %>  
   <div class="bg-light-gray/75 p-4 rounded shadow mb-4">
     <div class="text-sm text-dark-gray"><%= Time.current.strftime("%y年%m月%d日") %></div>
     <%= f.text_area :body, placeholder: "今日の出来事は？", rows: 5, class: "bg-light-gray w-full p-2 border rounded text-gray" %>

--- a/app/views/exchange_diaries/index.html.erb
+++ b/app/views/exchange_diaries/index.html.erb
@@ -1,6 +1,5 @@
 <div class="container mx-auto px-4">
   <div class="max-w-xl mx-auto">
-
     <%= render partial: 'exchange_diary', locals: { exchange_diaries: @exchange_diaries } %>
     <% if @diary_count < 2 %>
       <%= render 'form' %>
@@ -18,3 +17,4 @@
   </div>
   <%= paginate @exchange_diaries %>
 </div>
+<%= link_to '部屋に戻る', rooms_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,13 @@
 
     <%= yield :head %>
 
+    <% flash.each do |key, message| %>
+      <% text_color = key == "notice" ? "text-matcha" : "text-brown" %>
+      <div class="flash <%= key %> <%= text_color %> font-semibold">
+        <%= message %>
+      </div>
+    <% end %>
+
     <link rel="manifest" href="/manifest.json">
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">

--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -1,0 +1,18 @@
+<%= form_with model: @room, url: rooms_path, remote: true do |f| %>
+  <% if @room.errors.any? %>
+    <div class= "text-bold text-brown">
+        <% @room.errors.full_messages.each do |message| %>
+          <ul>
+            <li><%= message %></li>
+          </ul>
+        <% end %>
+    </div>
+  <% end %> 
+  <div class="bg-light-gray/75 p-4 rounded shadow mb-4">
+    <%= f.label :name, "家の名前", class: "text-sm text-dark-gray" %>
+    <%= f.text_field :name, placeholder: "家の名前を入力してください", class: "bg-light-gray w-full p-2 border rounded text-gray" %>
+    <div class="flex justify-center">
+      <%= f.submit "登録", class: "bg-light-blue text-dark-gray px-4 py-2 mt-2 rounded hover:bg-light-blue/80 transition" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -1,0 +1,30 @@
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 bg-light-gray/75 ">
+  <% @rooms.each do |room| %>
+    <div class="text-dark-gray rounded-lg shadow-md p-6">
+      <p>家の名前<i class="fa-solid fa-house-user text-light-blue"></i>:<%= link_to room.name, room_path(room), class: "text-matcha underline hover:text-matcha/60" %></p>
+      <p>住民:
+        <span class="<%= "text-dark-gray font-bold" if room.user == current_user %>">
+            <%= room.user.name %>
+        </span>
+      </p>
+      <p>入居日：<%= room.created_at.strftime("%y年%m月%d日") %></p>
+      <div class= "text-right">
+        <%= link_to "この家に帰宅する", room_path(room), class: "bg-light-blue text-dark-gray px-4 py-2 mt-2 rounded hover:bg-light-blue/80 transition" %>
+      </div>
+    </div>
+  <% end %>
+</div>
+<script>
+    document.addEventListener("DOMContentLoaded", () => {
+    const button = document.getElementById("room-form-button");
+    const form = document.getElementById("room-form");
+
+    if (button && form) {
+        button.addEventListener("click", (e) => {
+        e.preventDefault();
+        form.classList.remove("hidden");
+        button.classList.add("hidden");
+        });
+    }
+    });
+</script>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -1,0 +1,16 @@
+<div class="container mx-auto px-4 ">
+  <% if @current_user.rooms.empty? %>
+    <p class="text-white text-center text-lg">登録部屋はまだありません</p>
+    <div class="max-w-xl mx-auto">
+        <%= render 'form' %>
+    </div>
+  <% else %>
+    <%= render 'room' %>
+  <% end %>
+  <div class="text-center mt-4">
+    <%= button_to '<i class="fa-solid fa-plus text-gray/50"></i>'.html_safe, rooms_path, id: "room-form-button", method: :post, class: "text-3xl" %>
+  </div>
+  <div id="room-form" class="hidden mt-4">
+    <%= render 'form' %>
+  </div>
+</div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "交換日記", exchange_diaries_path %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,6 +7,9 @@
         <div class="text-xl text-brown text-center">
           <%= link_to "Online room", root_path, data: { turbo: false }, method: :delete %>
         </div>
+        <div class="text-brown flex space-x-2">
+          <%= link_to "玄関に行く", rooms_path,data: { turbo: false }, method: :delete %>
+        </div>
         <div class="text-brown flex space-x-4">
           <%= link_to "ログアウト", destroy_user_session_path,data: { turbo: false }, method: :delete %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "rooms/index"
   get "exchange_diaries/index"
   devise_for :users, controllers: {
   sessions: "users/sessions",
@@ -7,6 +8,7 @@ Rails.application.routes.draw do
   get "top/index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   resources :exchange_diaries, only: %i[index create]
+  resources :rooms, only: %i[index show create]
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20250521145528_create_rooms.rb
+++ b/db/migrate/20250521145528_create_rooms.rb
@@ -1,0 +1,9 @@
+class CreateRooms < ActiveRecord::Migration[7.2]
+  def change
+    create_table :rooms do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_21_050540) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_21_145528) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_21_050540) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_exchange_diaries_on_user_id"
+  end
+
+  create_table "rooms", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_rooms_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -36,4 +44,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_21_050540) do
   end
 
   add_foreign_key "exchange_diaries", "users"
+  add_foreign_key "rooms", "users"
 end

--- a/test/controllers/rooms_controller_test.rb
+++ b/test/controllers/rooms_controller_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class RoomsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    @user = User.create!(name: "TestUserFour", email: "test4@example.com", password: "password3")
+    @room = Room.create!(user: @user, name: "room")
+    sign_in @user
+  end
+
+  test "should get index" do
+    get rooms_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/rooms.yml
+++ b/test/fixtures/rooms.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one:
+  user: one
+  name: room1
+# column: value
+#
+two:
+  user: two
+  name: room2
+# column: value

--- a/test/models/room_test.rb
+++ b/test/models/room_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RoomTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 部屋の登録＆一人５部屋まで持てるよう制限

表題を実現するため、以下の作業をしました。
- roomモデル作成
- index,show,createアクション追加
- コントローラ＆ビューファイル作成・編集

# できるようになったこと
- ログイン後に部屋を作成し、名前を付けることができます
- 部屋一覧画面にて、部屋の名前・作成日時を確認し、個別の部屋に入ることができます。

# ここではまだできないこと
- 交換日記をroom_idと紐づけていないため、部屋ごとに交換日記を分けて表示していません。

# 作業ブランチ
- feature8/room