### PR TITLE
add/residence_area

### DIFF
--- a/app/controllers/areas_controller.rb
+++ b/app/controllers/areas_controller.rb
@@ -1,0 +1,25 @@
+class AreasController < ApplicationController
+  def create
+    @area = current_user.build_area(area_params)
+    if @area.save
+        redirect_to rooms_path, notice: "お住まいの地域を登録しました"
+    else
+        redirect_to root_path, alert: "地域の登録に失敗しました"
+    end
+  end
+
+  def update
+    @area = Area.find(params[:id])
+
+    if @area.update(area_params)
+      redirect_to rooms_path, notice: "お住まいの地域を更新しました"
+    else
+      redirect_to root_path, alert: "地域の変更に失敗しました"
+    end
+  end
+
+
+  def area_params
+    params.require(:area).permit(:city)
+  end
+end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -2,6 +2,7 @@ class RoomsController < ApplicationController
   def index
     @room = Room.new
     @rooms = current_user.rooms.includes(:user).order(created_at: :desc)
+    @area = current_user.area || current_user.build_area
   end
 
   def create
@@ -28,6 +29,7 @@ class RoomsController < ApplicationController
     end
     @whiteboards = @room.whiteboards.includes(:user).order(created_at: :desc)
     @whiteboard = @room.whiteboards.find_or_create_by(user: current_user)
+    @area = current_user.area
   end
 
   private

--- a/app/helpers/areas_helper.rb
+++ b/app/helpers/areas_helper.rb
@@ -1,0 +1,2 @@
+module AreasHelper
+end

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -1,0 +1,7 @@
+class Area < ApplicationRecord
+  belongs_to :user
+
+  validates :city, presence: true,
+                   format: { with: /\A[a-zA-Z]+\z/, message: "はローマ字（英字）のみで入力してください" }
+  validates :user_id, uniqueness: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :rooms
   has_many :exchange_diaries, dependent: :destroy
   has_many :whiteboards, dependent: :destroy
+  has_one :area, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/rooms/_area.html.erb
+++ b/app/views/rooms/_area.html.erb
@@ -1,0 +1,12 @@
+<%= form_with model: @area, local: true do |f| %>
+  <div class="bg-light-gray/75 p-4 rounded shadow mb-4">
+    <div>
+        <%= f.label :city, "あなたのお住まいの地域 *市or区 (ローマ字＆小文字で入力)" %>
+        <%= f.text_field :city, class: "bg-light-gray w-full p-2 border rounded text-gray" %>
+    </div>
+    <div class="flex justify-center">
+        <%= f.submit "変更", class: "class: bg-light-blue text-dark-gray px-4 py-2 mt-2 rounded hover:bg-light-blue/80 transition" %>
+    </div>
+  </div>
+<% end %>
+

--- a/app/views/rooms/_form_area.html.erb
+++ b/app/views/rooms/_form_area.html.erb
@@ -1,0 +1,10 @@
+<%= form_with(model: @area,  local: true ) do |f| %>
+  <div class="bg-light-gray/75 p-4 rounded shadow mb-4">
+    <%= f.label :city, "あなたのお住まいの地域 *市or区 (ローマ字＆小文字で入力)", class: "text-sm text-dark-gray" %>
+    <%= f.text_field :city, placeholder: "(例: shibuya)", class: "bg-light-gray w-full p-2 border rounded text-gray" %>
+    <div class="flex justify-center">
+      <%= f.submit "登録", class: "bg-light-blue text-dark-gray px-4 py-2 mt-2 rounded hover:bg-light-blue/80 transition" %>
+    </div>
+    <div class="text-gray text-right">*いずれもあとで変更可</div>
+  </div>
+<% end %>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -13,4 +13,10 @@
   <div id="room-form" class="hidden mt-4">
     <%= render 'form_room' %>
   </div>
+  <% if @area.nil? %>
+    <p class="text-dark-gray text-center text-lg">お住まいの地域が登録されていません</p>
+    <%= render 'form_area' %>
+  <% else %>
+    <%= render 'area' %>
+  <% end %>
 </div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -3,6 +3,12 @@
     <%= @room.name %> <i class="fa-solid fa-house-user text-light-blue"></i>
   </p>
 </div>
+<% if @area.nil? %>
+  <p>お住まいの地域が登録されていません</p>
+<% else %>
+  <p><%= @area.city %></p>
+<% end %>
+
 <%= render 'form_board' %>
 <%= render 'board' %>
 <%= link_to "交換日記", room_exchange_diaries_path(@room) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
     resources :exchange_diaries, only: %i[index create update destroy]
     resources :whiteboards, only: %i[create update]
   end
+
+  resources :areas, only: %i[create update]
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20250524144749_create_areas.rb
+++ b/db/migrate/20250524144749_create_areas.rb
@@ -1,0 +1,10 @@
+class CreateAreas < ActiveRecord::Migration[7.2]
+  def change
+    create_table :areas do |t|
+      t.references :user, null: false, foreign_key: true
+
+      t.string :city
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250524160028_add_index_to_areas_user_id.rb
+++ b/db/migrate/20250524160028_add_index_to_areas_user_id.rb
@@ -1,0 +1,6 @@
+class AddIndexToAreasUserId < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :areas, name: "index_areas_on_user_id"
+    add_index :areas, :user_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_22_103117) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_24_160028) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "areas", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "city"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_areas_on_user_id", unique: true
+  end
 
   create_table "exchange_diaries", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -55,6 +63,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_22_103117) do
     t.index ["user_id"], name: "index_whiteboards_on_user_id"
   end
 
+  add_foreign_key "areas", "users"
   add_foreign_key "exchange_diaries", "rooms"
   add_foreign_key "exchange_diaries", "users"
   add_foreign_key "rooms", "users"

--- a/test/controllers/areas_controller_test.rb
+++ b/test/controllers/areas_controller_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class AreasControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    @user = User.create!(name: "TestUserFour", email: "test4@example.com", password: "password3")
+    @area = Area.create!(user: @user, city: "amsterdam")
+    sign_in @user
+  end
+
+  test "should get index" do
+    get rooms_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/areas.yml
+++ b/test/fixtures/areas.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one:
+  user: one
+  city: amsterdam
+# column: value
+#
+two:
+  user: two
+  city: fukuoka
+# column: value

--- a/test/models/area_test.rb
+++ b/test/models/area_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AreaTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- Areaモデル作成 
```
docker compose exec web rails g model area
      invoke  active_record
      create    db/migrate/20250524144749_create_areas.rb
      create    app/models/area.rb
      invoke    test_unit
      create      test/models/area_test.rb
      create      test/fixtures/areas.yml
```

```
class CreateAreas < ActiveRecord::Migration[7.2]
  def change
    create_table :areas do |t|
      t.references :user, null: false, foreign_key: true

      t.string :city
      t.timestamps
    end
  end
end
```
```
$ docker compose exec web rails g controller areas
      create  app/controllers/areas_controller.rb
      invoke  tailwindcss
      create    app/views/areas
      invoke  test_unit
      create    test/controllers/areas_controller_test.rb
      invoke  helper
      create    app/helpers/areas_helper.rb
      invoke    test_unit
```
- Areaコントローラ作成&編集
- Roomコントローラindexに下記追加
- （上記が必要な理由）Area登録・編集フォームがroomのindexファイルにあるため。
```
@area = current_user.area || current_user.build_area

# 登録areaがあれば登録されたデータ（city)を表示し、なければ新しく追加します
```
- app/views/rooms/_area.html.erb
  - 登録エリアがすでにある場合、その場で編集できるフォームを表示
- app/views/rooms/_form_area.html.erb
  - 登録エリアがない場合、新規登録できるフォームを表示
 
# できるようになること
- 住んでいる地域の登録・編集ができます
-  住んでいる地域に結びついた天気情報の表示は未実装です

# 作業ブランチ
- feature15/add_area