### PR TITLE
add/weather_record

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,4 @@ gem "rails-i18n"
 gem "devise-i18n"
 
 gem "kaminari"
+gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,10 @@ GEM
     devise-i18n (1.13.0)
       devise (>= 4.9.0)
       rails-i18n
+    dotenv (3.1.8)
+    dotenv-rails (3.1.8)
+      dotenv (= 3.1.8)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.1)
     et-orbi (1.2.11)
@@ -372,6 +376,7 @@ DEPENDENCIES
   debug
   devise
   devise-i18n
+  dotenv-rails
   jbuilder
   jsbundling-rails
   kaminari

--- a/app/controllers/areas_controller.rb
+++ b/app/controllers/areas_controller.rb
@@ -1,4 +1,20 @@
+require "net/http"
+require "uri"
+require "json"
 class AreasController < ApplicationController
+  def index
+    api_key = ENV["WEATHER_API"]
+    city = "madagascar"
+    url = URI("https://api.openweathermap.org/data/2.5/weather?q=#{city}&appid=#{api_key}&units=metric&lang=ja")
+
+    response = Net::HTTP.get_response(url)
+    weather_data = JSON.parse(response.body)
+
+    Rails.logger.debug(weather_data)
+
+    @weather_data = weather_data
+  end
+
   def create
     @area = current_user.build_area(area_params)
     if @area.save

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -30,6 +30,7 @@ class RoomsController < ApplicationController
     @whiteboards = @room.whiteboards.includes(:user).order(created_at: :desc)
     @whiteboard = @room.whiteboards.find_or_create_by(user: current_user)
     @area = current_user.area
+    @weather_record = @area&.weather_record
   end
 
   private

--- a/app/controllers/weather_records_controller.rb
+++ b/app/controllers/weather_records_controller.rb
@@ -1,0 +1,60 @@
+require "net/http"
+require "uri"
+require "json"
+class WeatherRecordsController < ApplicationController
+  def create
+    city = params[:city]
+    Rails.logger.debug "送信された city パラメータ: #{city}"
+
+    area = Area.find(params[:area_id])
+    Rails.logger.debug "見つかった Area: #{area.inspect}"
+
+    api_data = fetch_weather_from_api(area.city)
+    Rails.logger.debug "取得した天気データ: #{api_data}"
+
+    if area
+      if api_data
+        @weather_record = WeatherRecord.new(
+            area_id: area.id,
+            temperature: api_data["main"]["temp"],
+            humidity: api_data["main"]["humidity"],
+            description: api_data["weather"][0]["description"],
+            temp_min: api_data["main"]["temp_min"],
+            temp_max: api_data["main"]["temp_max"]
+        )
+        if @weather_record.save
+            redirect_to rooms_path, notice: "天気情報を更新しました"
+        else
+            redirect_to areas_path, alert: "天気情報の保存に失敗しました"
+        end
+      else
+        redirect_to root_path, alert: "天気情報を取得できませんでした。"
+      end
+    else
+        redirect_to root_path, alert: "お住まいの地域が登録されていません。"
+    end
+  end
+
+  private
+
+  def fetch_weather_from_api(city)
+    api_key = ENV["WEATHER_API"]
+    url = URI("https://api.openweathermap.org/data/2.5/weather?q=#{city}&appid=#{api_key}&units=metric&lang=ja")
+    response = Net::HTTP.get_response(url)
+    if response.is_a?(Net::HTTPSuccess)
+        data = JSON.parse(response.body)
+        Rails.logger.debug "API description: #{data['weather'][0]['description']}"
+        data
+    else
+        Rails.logger.error "API request failed: #{response.code} #{response.message}"
+        nil
+    end
+  rescue => e
+    Rails.logger.error "Weather API error: #{e.message}"
+    nil
+  end
+
+  def weather_record_params
+    params.require(:weather_record).permit(:temperature, :humidity, :description, :temp_min, :temp_max)
+  end
+end

--- a/app/helpers/weather_records_helper.rb
+++ b/app/helpers/weather_records_helper.rb
@@ -1,0 +1,2 @@
+module WeatherRecordsHelper
+end

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -1,5 +1,6 @@
 class Area < ApplicationRecord
   belongs_to :user
+  has_one :weather_record
 
   validates :city, presence: true,
                    format: { with: /\A[a-zA-Z]+\z/, message: "はローマ字（英字）のみで入力してください" }

--- a/app/models/weather_record.rb
+++ b/app/models/weather_record.rb
@@ -1,0 +1,4 @@
+class WeatherRecord < ApplicationRecord
+  belongs_to :area
+  validates :area_id, uniqueness: true
+end

--- a/app/views/areas/index.html.erb
+++ b/app/views/areas/index.html.erb
@@ -1,0 +1,1 @@
+<pre><%= JSON.pretty_generate(@weather_data) %></pre>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= yield :head %>
 
     <% flash.each do |key, message| %>
-      <% text_color = key == "notice" ? "text-matcha" : "text-brown" %>
+      <% text_color = key == "notice" ? "text-matcha" : "text-red-500" %>
       <div class="flash <%= key %> <%= text_color %> font-semibold">
         <%= message %>
       </div>

--- a/app/views/rooms/_weather.html.erb
+++ b/app/views/rooms/_weather.html.erb
@@ -1,0 +1,13 @@
+<% if @area.nil? %>
+  <p>お住まいの地域が登録されていません</p>
+<% else %>
+  <p><%= @area.city %></p>
+  <%= button_to "天気を取得する", weather_records_path(area_id: @area.id), method: :post, data: { turbo: false } %>
+
+  <% if @weather_record %>
+    <p>天気: <%= @weather_record.description %></p>
+    <p>気温：<%= @weather_record.temperature %>℃</p>
+  <% else %>
+    <p>天気情報はまだありません</p>
+  <% end %>
+<% end %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -3,12 +3,7 @@
     <%= @room.name %> <i class="fa-solid fa-house-user text-light-blue"></i>
   </p>
 </div>
-<% if @area.nil? %>
-  <p>お住まいの地域が登録されていません</p>
-<% else %>
-  <p><%= @area.city %></p>
-<% end %>
-
+<%= render 'weather' %>
 <%= render 'form_board' %>
 <%= render 'board' %>
 <%= link_to "交換日記", room_exchange_diaries_path(@room) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,8 @@ Rails.application.routes.draw do
     resources :whiteboards, only: %i[create update]
   end
 
-  resources :areas, only: %i[create update]
+  resources :areas, only: %i[create update index]
+  resources :weather_records, only: %i[create]
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20250525034926_create_weather_records.rb
+++ b/db/migrate/20250525034926_create_weather_records.rb
@@ -1,0 +1,14 @@
+class CreateWeatherRecords < ActiveRecord::Migration[7.2]
+  def change
+    create_table :weather_records do |t|
+      t.references :area, null: false, foreign_key: true
+
+      t.float :temperature
+      t.float :humidity
+      t.string :description
+      t.float :temp_min
+      t.float :temp_max
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250525081323_add_index_weather_records_on_area_id.rb
+++ b/db/migrate/20250525081323_add_index_weather_records_on_area_id.rb
@@ -1,0 +1,6 @@
+class AddIndexWeatherRecordsOnAreaId < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :weather_records, name: "index_weather_records_on_area_id"
+    add_index :weather_records, :area_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_24_160028) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_25_081323) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,6 +53,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_24_160028) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "weather_records", force: :cascade do |t|
+    t.bigint "area_id", null: false
+    t.float "temperature"
+    t.float "humidity"
+    t.string "description"
+    t.float "temp_min"
+    t.float "temp_max"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["area_id"], name: "index_weather_records_on_area_id", unique: true
+  end
+
   create_table "whiteboards", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "room_id", null: false
@@ -67,6 +79,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_24_160028) do
   add_foreign_key "exchange_diaries", "rooms"
   add_foreign_key "exchange_diaries", "users"
   add_foreign_key "rooms", "users"
+  add_foreign_key "weather_records", "areas"
   add_foreign_key "whiteboards", "rooms"
   add_foreign_key "whiteboards", "users"
 end

--- a/test/controllers/weather_records_controller_test.rb
+++ b/test/controllers/weather_records_controller_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class WeatherRecordsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    @user = User.create!(name: "TestUserFour", email: "test4@example.com", password: "password3")
+    @area = Area.create!(user: @user, city: "amsterdam")
+    @weather_record = WeatherRecord.create!(temperature: 18, humidity: 50, description: "曇りがち", temp_min: 14, temp_max: 20, area: @area)
+    sign_in @user
+  end
+end

--- a/test/fixtures/weather_records.yml
+++ b/test/fixtures/weather_records.yml
@@ -5,13 +5,19 @@
 # below each fixture, per the syntax in the comments below
 #
 one:
-  id: 3
-  user: one
-  city: amsterdam
+  area_id: 3
+  temperature: 18
+  humidity: 50
+  description: "曇りがち"
+  temp_min: 14
+  temp_max: 20
 # column: value
 #
 two:
-  id: 4
-  user: two
-  city: fukuoka
+  area_id: 4
+  temperature: 14
+  humidity: 30
+  description: "晴天"
+  temp_min: 12
+  temp_max: 27
 # column: value

--- a/test/models/weather_record_test.rb
+++ b/test/models/weather_record_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class WeatherRecordTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- [x]  Weather_recordsモデル作成
- [x] ルーティング、コントローラ、ビューファイル作成（OpenWeatherAPIのキーも追記）
- [x] Areasモデルのcityカラムから、天気情報を取得し、Weather_recordsテーブルに保存

# できること
- 登録地域の天気情報を表示し、保存します。
# できないこと
- 一度天気情報を取得できるだけで、２回目以降の更新機能がついていません。

# 作業ブランチ
- feature16/area_weather