### PR TITLE
Feature18/add state calender

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,5 @@ gem "devise-i18n"
 
 gem "kaminari"
 gem "dotenv-rails"
+
+gem "simple_calendar"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,6 +296,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    simple_calendar (3.1.0)
+      rails (>= 6.1)
     solid_cable (3.0.8)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -387,6 +389,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails-omakase
   selenium-webdriver
+  simple_calendar
   solid_cable
   solid_cache
   solid_queue

--- a/app/controllers/areas_controller.rb
+++ b/app/controllers/areas_controller.rb
@@ -2,6 +2,8 @@ require "net/http"
 require "uri"
 require "json"
 class AreasController < ApplicationController
+  before_action :set_area, only: [ :update ]
+
   def index
     api_key = ENV["WEATHER_API"]
     city = "madagascar"
@@ -17,23 +19,66 @@ class AreasController < ApplicationController
 
   def create
     @area = current_user.build_area(area_params)
-    if @area.save
-        redirect_to rooms_path, notice: "お住まいの地域を登録しました"
+
+    if save_area_weather!(@area)
+      redirect_to rooms_path, notice: "地域を登録しました"
     else
-        redirect_to root_path, alert: "地域の登録に失敗しました"
+      redirect_to areas_path, alert: "天気情報を取得できない都市名です。都市名をご確認ください。"
     end
   end
 
   def update
-    @area = Area.find(params[:id])
-
-    if @area.update(area_params)
+    @area.assign_attributes(area_params)
+    if save_area_weather!(@area)
       redirect_to rooms_path, notice: "お住まいの地域を更新しました"
     else
       redirect_to root_path, alert: "地域の変更に失敗しました"
     end
   end
 
+  private
+
+  def set_area
+    @area = Area.find(params[:id])
+  end
+
+  def fetch_weather_from_api(city)
+    api_key = ENV["WEATHER_API"]
+    url = URI("https://api.openweathermap.org/data/2.5/weather?q=#{city}&appid=#{api_key}&units=metric&lang=ja")
+    response = Net::HTTP.get_response(url)
+    if response.is_a?(Net::HTTPSuccess)
+        data = JSON.parse(response.body)
+        Rails.logger.debug "API description: #{data['weather'][0]['description']}"
+        data
+    else
+        Rails.logger.error "API request failed: #{response.code} #{response.message}"
+        nil
+    end
+  rescue => e
+    Rails.logger.error "Weather API error: #{e.message}"
+    nil
+  end
+
+  def save_area_weather!(area)
+    api_data = fetch_weather_from_api(area.city)
+    return false unless api_data.present?
+
+    ActiveRecord::Base.transaction do
+      area.save!
+      weather_record = area.weather_record || area.build_weather_record
+      weather_record.update!(
+        temperature: api_data["main"]["temp"],
+        humidity: api_data["main"]["humidity"],
+        description: api_data["weather"][0]["description"],
+        temp_min: api_data["main"]["temp_min"],
+        temp_max: api_data["main"]["temp_max"]
+      )
+    end
+    true
+  rescue => e
+    Rails.logger.error "保存エラー: #{e.message}"
+    false
+  end
 
   def area_params
     params.require(:area).permit(:city)

--- a/app/controllers/exchange_diaries_controller.rb
+++ b/app/controllers/exchange_diaries_controller.rb
@@ -17,25 +17,25 @@ class ExchangeDiariesController < ApplicationController
   end
 
   def create
-  @room = Room.find(params[:room_id])
-  @exchange_diary = current_user.exchange_diaries.new(exchange_diary_params)
-  @exchange_diary.room = @room
+    @room = Room.find(params[:room_id])
+    @exchange_diary = current_user.exchange_diaries.new(exchange_diary_params)
+    @exchange_diary.room = @room
 
-    if @exchange_diary.save
-      respond_to do |format|
-        format.html { redirect_to room_exchange_diaries_path(@room), notice: "日記を保存しました" }
-        format.json { render json: { id: @exchange_diary.id }, status: :created }
-      end
-    else
-      respond_to do |format|
-        format.html do
-          flash.now[:alert] = "日記の保存に失敗しました"
-          @exchange_diaries = @room.exchange_diaries.order(created_at: :desc)
-          render :index, status: :unprocessable_entity
+      if @exchange_diary.save
+        respond_to do |format|
+          format.html { redirect_to room_exchange_diaries_path(@room), notice: "日記を保存しました" }
+          format.json { render json: { id: @exchange_diary.id }, status: :created }
         end
-        format.json { render json: @exchange_diary.errors.full_messages, status: :unprocessable_entity }
+      else
+        respond_to do |format|
+          format.html do
+            flash.now[:alert] = "日記の保存に失敗しました"
+            @exchange_diaries = @room.exchange_diaries.order(created_at: :desc)
+            render :index, status: :unprocessable_entity
+          end
+          format.json { render json: @exchange_diary.errors.full_messages, status: :unprocessable_entity }
+        end
       end
-    end
   end
 
   respond_to :html, :json

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -31,6 +31,10 @@ class RoomsController < ApplicationController
     @whiteboard = @room.whiteboards.find_or_create_by(user: current_user)
     @area = current_user.area
     @weather_record = @area&.weather_record
+
+    @state_calendars = @room.state_calendars.includes(:user).order(created_at: :desc)
+    @state_calendar = current_user.state_calendars.new
+    @calendar_users = @state_calendars.includes(:user).map(&:user).uniq
   end
 
   private

--- a/app/controllers/state_calendars_controller.rb
+++ b/app/controllers/state_calendars_controller.rb
@@ -1,0 +1,52 @@
+class StateCalendarsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_room
+  def index
+    @room = Room.find(params[:room_id])
+    @state_calendars = @room.state_calendars.includes(:user).order(created_at: :desc)
+    @state_calendar = current_user.state_calendars.new
+    @calendar_users = @state_calendars.includes(:user).map(&:user).uniq
+  end
+
+  def new
+    @room = Room.find(params[:room_id])
+    @state_calendar = current_user.state_calendars.new
+    @state_calendar.room = @room
+    @state_calendar.date = params[:date] || Date.current
+  end
+
+  def create
+    @room = Room.find(params[:room_id])
+    @state_calendar = current_user.state_calendars.new(state_calendar_params)
+    @state_calendar.room = @room
+
+    if @state_calendar.save
+        respond_to do |format|
+          format.html { redirect_to room_state_calendars_path(@room), notice: "心身コンディションを保存しました" }
+          format.json { render json: { id: @state_calendar.id }, status: :created }
+        end
+    else
+        respond_to do |format|
+          format.html do
+            flash.now[:alert] = "心身コンディションの保存に失敗しました"
+            @state_calendars = @room.state_calendars.order(created_at: :desc)
+            render :new, status: :unprocessable_entity
+          end
+          format.json { render json: @state_calendar.errors.full_messages, status: :unprocessable_entity }
+        end
+    end
+  end
+
+  private
+
+  def set_room
+    @room = current_user.rooms.find_by(id: params[:room_id])
+    unless @room
+      redirect_to root_path, alert: "部屋が見つかりませんでした。"
+    end
+  end
+
+  def state_calendar_params
+    params.require(:state_calendar).permit(:mental_state, :physical_state, :date)
+  end
+end

--- a/app/helpers/state_calendars_helper.rb
+++ b/app/helpers/state_calendars_helper.rb
@@ -1,0 +1,2 @@
+module StateCalendarsHelper
+end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -2,6 +2,7 @@ class Room < ApplicationRecord
   belongs_to :user
   has_many :exchange_diaries, dependent: :destroy
   has_many :whiteboards, dependent: :destroy
+  has_many :state_calendars, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 30 }
 end

--- a/app/models/state_calendar.rb
+++ b/app/models/state_calendar.rb
@@ -1,0 +1,11 @@
+class StateCalendar < ApplicationRecord
+  belongs_to :user
+  belongs_to :room
+
+  validates :mental_state, presence: true, inclusion: { in: [ "🥳", "☺", "😐", "😭", "😣" ] }
+  validates :physical_state, presence: true, inclusion: { in: [ "💃", "🚶‍♀️", "🧍‍♀️", "🛌", "🤒" ] }
+
+  def calendar_date
+    date.presence || created_at
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   has_many :exchange_diaries, dependent: :destroy
   has_many :whiteboards, dependent: :destroy
   has_one :area, dependent: :destroy
+  has_many :state_calendars, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/rooms/_calendar.html.erb
+++ b/app/views/rooms/_calendar.html.erb
@@ -1,0 +1,41 @@
+<div class="text-center mt-4">
+  <button id="calendar-button" class="text-3xl">
+    <i class="fa-regular fa-calendar-days"></i>
+  </button>
+</div>
+
+<div
+  id="calendar-wrapper"
+  class="hidden inline-block max-w-[30%] w-full cursor-pointer rounded shadow-lg hover:ring-2 hover:ring-blue transition"
+  data-url="<%= room_state_calendars_path(@room) %>"
+>
+  <%= week_calendar(events: @state_calendars, attribute: :calendar_date) do |date, states_on_day| %>
+    <% states_on_day.each do |state| %>
+      <p><%= state.mental_state %></p>
+      <p><%= state.physical_state %></p>
+    <% end %>
+  <% end %>
+</div>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    const wrapper = document.getElementById("calendar-wrapper");
+    const button = document.getElementById("calendar-button");
+
+    if (wrapper) {
+      wrapper.addEventListener("click", function () {
+        const url = wrapper.dataset.url;
+        if (url) window.location.href = url;
+      });
+    }
+
+    if (button && wrapper) {
+      button.addEventListener("click", function (e) {
+        e.preventDefault();
+        wrapper.classList.toggle("hidden");
+      });
+    }
+  });
+</script>
+
+

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -7,3 +7,4 @@
 <%= render 'form_board' %>
 <%= render 'board' %>
 <%= link_to "交換日記", room_exchange_diaries_path(@room) %>
+<%= render 'calendar' %>

--- a/app/views/simple_calendar/_calendar.html.erb
+++ b/app/views/simple_calendar/_calendar.html.erb
@@ -1,0 +1,33 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <%= content_tag :tr, class: calendar.tr_classes_for(week) do %>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,0 +1,45 @@
+<div class="simple-calendar rounded-2xl border border-gray shadow-lg p-4 bg-white max-w-4xl mx-auto">
+  <div class="text-lg font-semibold text-gray mb-2">
+    <i class="fa-solid fa-user"></i>
+    <% @calendar_users.each do |user| %>
+      <span class="<%= 'text-blue font-bold' if user == current_user %>">
+        <%= user.name %>
+      </span><% unless user == @calendar_users.last %>, <% end %>
+    <% end %>
+    さんのカレンダー
+  </div>
+  <div class="calendar-heading flex items-center justify-between mb-4">
+    <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title text-xl font-semibold text-dark-gray">
+      <%= t('date.month_names')[start_date.month] %> <%= start_date.year %>
+    </time>
+
+    <nav class="space-x-2">
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view, class: "px-3 py-1 bg-light-gray/50 hover:bg-light-gray rounded-lg text-sm text-dark-gray" %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view, class: "px-3 py-1 bg-green-100 hover:bg-green-200 rounded-lg text-sm text-green-700" %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view, class: "px-3 py-1 bg-light-gray/50 hover:bg-light-gray rounded-lg text-sm text-dark-gray" %>
+    </nav>
+  </div>
+
+  <table class="table-auto w-full text-center border-collapse">
+    <thead>
+      <tr class="bg-light-blue">
+        <% date_range.slice(0, 7).each do |day| %>
+          <th class="p-2 text-dark-gray text-sm"><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: "#{calendar.td_classes_for(day)} border p-2 align-top hover:bg-light-blue/50 transition duration-200 ease-in-out" do %>
+              <%= link_to day.day, new_room_state_calendar_path(@room, date: day.to_date), class: "block w-full h-full" %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -1,0 +1,48 @@
+<div class="simple-calendar rounded-2xl border border-gray shadow-lg p-4 bg-white max-w-4xl mx-auto">
+  <div class="text-sm font-semibold text-gray mb-2">
+    <i class="fa-solid fa-user"></i>
+    <% @calendar_users.each do |user| %>
+      <span class="<%= 'text-blue font-bold' if user == current_user %>">
+        <%= user.name %>
+      </span><% unless user == @calendar_users.last %>, <% end %>
+    <% end %>
+    さんのカレンダー
+  </div>
+  <div class="calendar-heading flex items-center justify-between mb-4">
+    <span class="calendar-title text-sm font-semibold text-gray">
+      <%= t('simple_calendar.week', default: 'Week') %> <%= calendar.week_number %>
+      <% if calendar.number_of_weeks > 1 %>
+        - <%= calendar.end_week %>
+      <% end %>
+    </span>
+
+    <nav class="space-x-2">
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view, class: "px-3 py-1 bg-light-gray/50 hover:bg-light-gray rounded-lg text-sm text-dark-gray" %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view, class: "px-3 py-1 bg-green-100 hover:bg-green-200 rounded-lg text-sm text-green-700" %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view, class: "px-3 py-1 bg-light-gray/50 hover:bg-light-gray rounded-lg text-sm text-dark-gray" %>
+    </nav>
+  </div>
+
+  <table class="table-auto w-full text-center border-collapse">
+    <thead>
+      <tr class="bg-light-blue">
+        <% date_range.slice(0, 7).each do |day| %>
+          <th class="p-2 text-dark-gray text-sm"><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: "#{calendar.td_classes_for(day)} border p-2 align-top hover:bg-light-blue/50 transition duration-200 ease-in-out" do %>
+              <%= link_to day.day, new_room_state_calendar_path(@room, date: day.to_date), class: "block w-full h-full" %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/state_calendars/index.html.erb
+++ b/app/views/state_calendars/index.html.erb
@@ -1,0 +1,13 @@
+<%= month_calendar(events: @state_calendars, attribute: :calendar_date) do |date, states_on_day| %>
+  <% states_on_day.each do |state| %>
+    <div class= "flex">
+        <%= state.mental_state %>
+        <%= state.physical_state %>
+    </div>
+  <% end %>
+<% end %>
+
+<%= link_to "+ 心身の登録", new_room_state_calendar_path(@room) %>
+<div class="text-brown flex space-x-2">
+    <%= link_to "部屋に戻る", room_path(@room),data: { turbo: false }, method: :delete %>
+</div>

--- a/app/views/state_calendars/new.html.erb
+++ b/app/views/state_calendars/new.html.erb
@@ -1,0 +1,34 @@
+<%= link_to "一覧へもどる", room_state_calendars_path(@room) %>
+
+<%= form_with model: @state_calendar, url: room_state_calendars_path(@room), local: true, data: { turbo: false } do |f| %>
+  <%= f.date_field :date, value: @state_calendar.date || Date.current %>
+  <div class="field">
+    <%= f.label :mental_state, "心の状態" %><br>
+    <%= f.select :mental_state, 
+      [
+        ["🥳 : とても元気", "🥳"],
+        ["☺ : 元気", "☺"],
+        ["😐 : 少しもやっとしている", "😐"],
+        ["😭 : 激しい落ち込み・涙が出る", "😭"],
+        ["😣 : SOS / 相談に乗ってほしい", "😣"]
+      ], 
+      prompt: "一番近い状態を選ぶ" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :physical_state, "体の状態" %><br>
+    <%= f.select :physical_state, 
+      [
+        ["💃 : エネルギッシュ", "💃"],
+        ["🚶‍♀️ : 元気", "🚶‍♀️"],
+        ["🧍‍♀️ : 少しだるい", "🧍‍♀️"],
+        ["🛌 : とても辛くて動けない", "🛌"],
+        ["🤒 : SOS / 声をかけてほしい", "🤒"]
+      ], 
+      prompt: "一番近い状態を選ぶ" %>
+  </div>
+
+  <%= f.submit "保存", style: "padding: 10px 20px; background-color: #ccc;" %>
+<% end %>
+
+

--- a/app/views/state_calendars/show.html.erb
+++ b/app/views/state_calendars/show.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "index_calendar", room_state_calendars_path(@room) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   resources :rooms, only: %i[index show create] do
     resources :exchange_diaries, only: %i[index create update destroy]
     resources :whiteboards, only: %i[create update]
+    resources :state_calendars, only: %i[new create index]
   end
 
   resources :areas, only: %i[create update index]

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -11,6 +11,9 @@ module.exports = {
     extend: {
       colors: {
         'light-blue': '#A3B9C9',
+        'blue' : '#8DA8BB',
+        'bright-blue' : '#7F9BB3',
+        'gray-blue': '#8FA6B8',
         'beige': '#F8F8F0',
         'brown': '#A1866F',
         'dark-gray': '#404040',

--- a/db/migrate/20250526040007_create_state_calendars.rb
+++ b/db/migrate/20250526040007_create_state_calendars.rb
@@ -1,0 +1,12 @@
+class CreateStateCalendars < ActiveRecord::Migration[7.2]
+  def change
+    create_table :state_calendars do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :room, null: false, foreign_key: true
+
+      t.string :mental_state
+      t.string :physical_state
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250526110258_add_date_to_state_calendars.rb
+++ b/db/migrate/20250526110258_add_date_to_state_calendars.rb
@@ -1,0 +1,5 @@
+class AddDateToStateCalendars < ActiveRecord::Migration[7.2]
+  def change
+    add_column :state_calendars, :date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_25_081323) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_26_110258) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,6 +38,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_25_081323) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_rooms_on_user_id"
+  end
+
+  create_table "state_calendars", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "room_id", null: false
+    t.string "mental_state"
+    t.string "physical_state"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.date "date"
+    t.index ["room_id"], name: "index_state_calendars_on_room_id"
+    t.index ["user_id"], name: "index_state_calendars_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -79,6 +91,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_25_081323) do
   add_foreign_key "exchange_diaries", "rooms"
   add_foreign_key "exchange_diaries", "users"
   add_foreign_key "rooms", "users"
+  add_foreign_key "state_calendars", "rooms"
+  add_foreign_key "state_calendars", "users"
   add_foreign_key "weather_records", "areas"
   add_foreign_key "whiteboards", "rooms"
   add_foreign_key "whiteboards", "users"

--- a/test/controllers/state_calendars_controller_test.rb
+++ b/test/controllers/state_calendars_controller_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class StateCalendarsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    @user = User.create!(name: "TestUserThree", email: "test3@example.com", password: "password3")
+    @room = Room.create!(user: @user, name: "room")
+    @state_calendar = StateCalendar.create!(user: @user, room: @room, mental_state: "🥳", physical_state: "💃", date: "2025-05-01")
+    sign_in @user
+  end
+
+  test "should get index" do
+    get room_state_calendars_url(@room)
+    assert_response :success
+  end
+end

--- a/test/fixtures/state_calendars.yml
+++ b/test/fixtures/state_calendars.yml
@@ -1,0 +1,21 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one:
+  user: one
+  room: one
+  mental_state: 🥳
+  physical_state: 💃
+  date: 2025-05-01
+# column: value
+#
+two:
+  user: two
+  room: two
+  mental_state: 🥳
+  physical_state: 💃
+  date: 2025-05-25
+# column: value

--- a/test/models/state_calendar_test.rb
+++ b/test/models/state_calendar_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class StateCalendarTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# カレンダー形式で心身状況を記録できるよう実装

- [x] status_calendarsモデル作成
- [x] gem "simple_calendar"導入
- [x] ルーティング、コントローラ、ビューファイル作成
- [x] calendarのカスタムビューファイル追加
- [x] mentalとphysicalのそれぞれを、５段階評価で選べるようにビューファイル追記
- [x] weekly表示とmonthly表示追加

# できること
- トップ画面で週カレンダーを閲覧可能です。
- 週カレンダー全体がボタンになっており、クリックで月カレンダーに遷移します。
- 月カレンダーから、新しく心身状況を記録できます。
- 日にちをクリックし、過去の日付に記録することも可能です。

# できないこと
- 登録した心身状況の編集・削除は未実装です。

# 作業ブランチ
- feature18/add_state_calender