### PR TITLE
update_delete_state_calendar

### DIFF
--- a/app/models/state_calendar.rb
+++ b/app/models/state_calendar.rb
@@ -8,4 +8,12 @@ class StateCalendar < ApplicationRecord
   def calendar_date
     date.presence || created_at
   end
+
+  validate :one_state_per_day, on: :create
+
+  def one_state_per_day
+    if StateCalendar.exists?(user_id: user_id, date: date)
+      errors.add(:base, "この日はすでに記録があります")
+    end
+  end
 end

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -7,4 +7,7 @@
 <%= render 'form_board' %>
 <%= render 'board' %>
 <%= link_to "交換日記", room_exchange_diaries_path(@room) %>
-<%= render 'calendar' %>
+<div class="flex">
+  <%= render 'calendar' %>
+  <%= link_to 'カレンダー一覧', room_state_calendars_path(@room) %>
+</div>

--- a/app/views/state_calendars/new.html.erb
+++ b/app/views/state_calendars/new.html.erb
@@ -1,6 +1,6 @@
 <%= link_to "一覧へもどる", room_state_calendars_path(@room) %>
 
-<%= form_with model: @state_calendar, url: room_state_calendars_path(@room), local: true, data: { turbo: false } do |f| %>
+<%= form_with model: @state_calendar, url: @form_url, method: @form_method, local: true do |f| %>
   <%= f.date_field :date, value: @state_calendar.date || Date.current %>
   <div class="field">
     <%= f.label :mental_state, "心の状態" %><br>
@@ -27,8 +27,12 @@
       ], 
       prompt: "一番近い状態を選ぶ" %>
   </div>
-
-  <%= f.submit "保存", style: "padding: 10px 20px; background-color: #ccc;" %>
+  <div class="flex">
+    <%= f.submit @form_method == :patch ? "更新" : "保存", style: "padding: 10px 20px; background-color: #ccc;" %>
+    <% if @form_method == :patch %>
+      <%= link_to '<i class="fa-solid fa-trash text-lg text-blue"></i>'.html_safe, room_state_calendar_path(@room, @state_calendar), data: { turbo_method: :delete, turbo_confirm: "本当に記録を消しますか？" } %>
+    <% end %>
+  </div>
 <% end %>
 
 

--- a/app/views/state_calendars/show.html.erb
+++ b/app/views/state_calendars/show.html.erb
@@ -1,1 +1,0 @@
-<%= link_to "index_calendar", room_state_calendars_path(@room) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   resources :rooms, only: %i[index show create] do
     resources :exchange_diaries, only: %i[index create update destroy]
     resources :whiteboards, only: %i[create update]
-    resources :state_calendars, only: %i[new create index]
+    resources :state_calendars, only: %i[new create index update destroy]
   end
 
   resources :areas, only: %i[create update index]

--- a/db/migrate/20250526145122_add_unique_index_to_state_calendars.rb
+++ b/db/migrate/20250526145122_add_unique_index_to_state_calendars.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToStateCalendars < ActiveRecord::Migration[7.2]
+  def change
+    add_index :state_calendars, [ :user_id, :date ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_26_110258) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_26_145122) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,6 +49,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_26_110258) do
     t.datetime "updated_at", null: false
     t.date "date"
     t.index ["room_id"], name: "index_state_calendars_on_room_id"
+    t.index ["user_id", "date"], name: "index_state_calendars_on_user_id_and_date", unique: true
     t.index ["user_id"], name: "index_state_calendars_on_user_id"
   end
 


### PR DESCRIPTION
# カレンダー形式で心身状況を編集・削除機能を実装
- updateとdestroyをルーティングに追記
- state_calenderのコントローラにupdate, destroy追記
- update,destroy,createをnewページですべて行うため、newアクションも編集
- バリデーション追加: １ユーザーにつき１日１つの記録（state_calendar)のみ持てる
- マイグレーションファイルに追記: state_calendarは固有のuser_id及びdateしか持てない（バリデーションと併用して、１ユーザー・１日・１記録に制限）
  ```
  t.index ["user_id", "date"], name: "index_state_calendars_on_user_id_and_date", unique: true
  ```

# できるようになること
- カレンダー形式で登録した心身状況を１日単位で更新・削除できます

# 作業ブランチ
- feature19/edit_delete_state_calendar
