### PR TITLE
fix/new_calendar_display

### DIFF
--- a/app/controllers/state_calendars_controller.rb
+++ b/app/controllers/state_calendars_controller.rb
@@ -4,7 +4,7 @@ class StateCalendarsController < ApplicationController
   def index
     @room = Room.find(params[:room_id])
     @state_calendars = @room.state_calendars.includes(:user).order(created_at: :desc)
-    @calendar_users = @state_calendars.includes(:user).map(&:user).uniq
+    @calendar_users = @room.users
     @calendars_by_user = @state_calendars.group_by(&:user_id)
   end
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -4,6 +4,7 @@ class Room < ApplicationRecord
   has_many :whiteboards, dependent: :destroy
   has_many :state_calendars, dependent: :destroy
   has_many :roommate_lists, dependent: :destroy
+  has_many :users, through: :roommate_lists
   has_many :roommates, through: :roommate_lists, source: :user
   has_many :invitation_tokens
   has_many :greetings, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   has_one :area, dependent: :destroy
   has_many :state_calendars, dependent: :destroy
   has_many :roommate_lists, dependent: :destroy
+  has_many :rooms, through: :roommate_lists
   has_many :invitation_tokens, dependent: :destroy
   has_many :greetings, dependent: :destroy
   # Include default devise modules. Others available are:

--- a/app/views/state_calendars/index.html.erb
+++ b/app/views/state_calendars/index.html.erb
@@ -1,31 +1,39 @@
 <% @calendar_users.each do |user| %>
-  <% @user_is_current = user == current_user %>
-  <div class="user-calendar mb-8 p-4 border rounded <%= user == current_user ? 'border-blue' : 'border-gray' %>">
-    <h3 class="font-semibold mb-2 <%= user == current_user ? 'text-blue' : 'text-gray' %>">
+  <% user_is_current = user == current_user %>
+  <% user_calendars = @calendars_by_user[user.id] || [] %>
+  <div class="user-calendar mb-8 p-4 border rounded <%= user_is_current ? 'border-bright-blue' : 'border-gray' %>">
+    <h3 class="font-semibold mb-2 <%= user_is_current ? 'text-bright-blue' : 'text-gray' %>">
       <i class="fa-solid fa-user"></i> <%= user.name %> さんのカレンダー
     </h3>
-
-    <%= month_calendar(events: @calendars_by_user[user.id] || [], attribute: :calendar_date) do |date, states_on_day| %>
-      <% has_data = states_on_day.present? %>
-      <% if @user_is_current %>
-        <% if has_data %>
-          <% state_calendar = states_on_day.first %>
-          <%= link_to date.day, edit_room_state_calendar_path(@room, state_calendar, date: date), class: "block w-full h-full" %>
-        <% else %>
-          <%= link_to date.day, new_room_state_calendar_path(@room, date: date), class: "block w-full h-full" %>
-        <% end %>
-      <% else %>
-        <span class="block w-full h-full"><%= date.day %></span>
+    <% if user_calendars.empty? && user_is_current %>
+      <%= month_calendar(events: [], attribute: :calendar_date) do |date, _| %>
+        <%= link_to date.day, new_room_state_calendar_path(@room, date: date), class: "block w-full h-full text-center" %>
       <% end %>
-      <% states_on_day.each do |state| %>
-        <div class="flex space-x-2 mb-1">
-          <span class="px-1 py-1 rounded bg-yellow"><%= state.mental_state %></span>
-          <span class="px-1 py-1 rounded bg-light-blue/30"><%= state.physical_state %></span>
-        </div>
+
+    <% else %>
+      <%= month_calendar(events: user_calendars, attribute: :calendar_date) do |date, states_on_day| %>
+        <% if user_is_current %>
+          <% if states_on_day.present? %>
+            <% state_calendar = states_on_day.first %>
+            <%= link_to date.day, edit_room_state_calendar_path(@room, state_calendar, date: date), class: "block w-full h-full text-center" %>
+          <% else %>
+            <%= link_to date.day, new_room_state_calendar_path(@room, date: date), class: "block w-full h-full text-center" %>
+          <% end %>
+        <% else %>
+          <span class="block w-full h-full text-center"><%= date.day %></span>
+        <% end %>
+
+        <% states_on_day.each do |state| %>
+          <div class="flex space-x-2 mb-1">
+            <span class="px-1 py-1 rounded bg-yellow"><%= state.mental_state %></span>
+            <span class="px-1 py-1 rounded bg-light-blue/30"><%= state.physical_state %></span>
+          </div>
+        <% end %>
       <% end %>
     <% end %>
   </div>
 <% end %>
+
 
 <%= link_to "+ 心身の登録", new_room_state_calendar_path(@room) %>
 <div class="text-brown flex space-x-2">


### PR DESCRIPTION
# 心身カレンダーの新規作成時にカレンダー表示
（新規フォームを兼ねていたカレンダーが、編集時にしか出てこないため修正）

- [x] app/views/state_calendars/index.html.erbを編集し、データがなくてもカレンダー表示
  ```
  <% @calendar_users.each do |user| %>

  # userごとにカレンダーを個別に表示したいため、userごとに回す
  ```
- [x] app/controllers/state_calendars_controller.rbを編集し、データがなくてもカレンダー表示
  ```
  ⓵　@calendar_users = @state_calendars.includes(:user).map(&:user).uniq
  　　　↓ 編集
  ⓶　@calendar_users = @room.users

  # ⓵だと、カレンダーに記録があるuserだけを回している
  # ②だと、部屋にいる全員のユーザーを回しているため、データがないuserのカレンダーも表示できる
  ```

# 修正前
- 新規作成時、カレンダーが出ないため日にちセルを選択できず保存エラーが起きる

# 修正後
- データがない状態でもカレンダーが表示され、日にちセルから新規作成リンクに遷移＆保存できる

# 作業ブランチ
- feature25/fix_calendar_new