### PR TITLE
fix/invited_own_room

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   validates :name, presence: true
 
-  has_many :rooms
+  has_many :owned_rooms, class_name: "Room", foreign_key: "user_id", dependent: :destroy
   has_many :exchange_diaries, dependent: :destroy
   has_many :whiteboards, dependent: :destroy
   has_one :area, dependent: :destroy


### PR DESCRIPTION
# room/indexファイルで、部屋の新規作成ができないエラー修正
(エラーの背景)
- room/indexページに、自分で作成した部屋だけでなく、招待された部屋も表示されるよう実装済み
- 招待された部屋をindexページで呼び出すため、以下のように変数を定義
  ```
  # Userモデル
  has_many :rooms, through: :roommate_lists

  # roomsコントローラ
  def invited_and_own_room
    my_rooms = current_user.rooms
    join_rooms = Room.joins(:invitation_tokens).where(invitation_tokens: { invited_user: current_user.id })
    @rooms = (my_rooms + join_rooms).uniq
    @invitation_map = InvitationToken
                      .where(invited_user: current_user, room_id: @rooms.map(&:id))
                      .index_by(&:room_id)
    @rooms = Room.where(id: @rooms.map(&:id)).includes(:user, :roommates)
    @area = current_user.area || current_user.build_area
  end
  ```
- （原因）上記で招待された部屋の定義は成功したが、下記の通り
Userモデルにある "room" と "招待されたroom" の名前が重複したこと➡もともとのroomの定義が崩れた
  ```
  # Userモデル (roomsが二つ定義されている）
  has_many :rooms, dependent: :destroy ➡(変更) has_many :owned_rooms, class_name: "Room", foreign_key: "user_id", dependent: :destroy
  has_many :rooms, through: :roommate_lists

  # roomsコントローラ
    my_rooms = current_user.rooms  ➡(変更) my_rooms = current_user.owned_rooms
  ```
- 上記のように修正後、自分の部屋と招待された部屋の両方に対応可能になりました。
# 作業ブランチ
- feature26/fix_index_room
   
