### PR TITLE
fix/calendar_index2

### DIFF
--- a/app/controllers/state_calendars_controller.rb
+++ b/app/controllers/state_calendars_controller.rb
@@ -4,8 +4,14 @@ class StateCalendarsController < ApplicationController
   def index
     @room = Room.find(params[:room_id])
     @state_calendars = @room.state_calendars.includes(:user).order(created_at: :desc)
-    @calendar_users = @room.users
+    @calendar_users = current_user.grouped_shared_users[@room.id] || []
+    logger.debug("grouped_shared_users keys: #{current_user.grouped_shared_users.keys}")
+    logger.debug("current room id: #{@room.id}")
     @calendars_by_user = @state_calendars.group_by(&:user_id)
+    logger.debug("@calendar_users count: #{@calendar_users.size}")
+    logger.debug("@calendar_users ids: #{@calendar_users.map(&:id)}")
+    logger.debug("@calendars_by_user keys: #{@calendars_by_user.keys}")
+    logger.debug("@state_calendars count: #{@state_calendars.size}")
   end
 
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,4 +18,14 @@ class User < ApplicationRecord
   def own?(object)
     id == object&.user_id
   end
+
+  # 同じ部屋に所属するユーザー全員
+  def grouped_shared_users
+    Room.where(id: owned_rooms.pluck(:id) + rooms.pluck(:id))
+      .includes(:users)
+      .each_with_object({}) do |room, hash|
+        all_users = (room.users + [ room.user ]).uniq
+        hash[room.id] = all_users
+      end
+  end
 end

--- a/app/views/state_calendars/index.html.erb
+++ b/app/views/state_calendars/index.html.erb
@@ -35,6 +35,7 @@
 <% end %>
 
 
+
 <%= link_to "+ 心身の登録", new_room_state_calendar_path(@room) %>
 <div class="text-brown flex space-x-2">
     <%= link_to "部屋に戻る", room_path(@room),data: { turbo: false }, method: :delete %>


### PR DESCRIPTION
# （エラー対応）一人暮らし部屋（招待なし）のとき、カレンダーが表示されない
- **前提：招待したとき、roommate_listに「部屋作成者」と「招待された人」がどちらも格納されます。**

- 前回のブランチで、下記のように定義
  ```
  （Userモデル）
  自分が作成した部屋➡owned_rooms
  招待された部屋➡rooms
  ```
- (原因)ここで、カレンダー表示をしているindexコントローラ・Roomモデルで以下の記述

  ```
  (state_calendarsコントローラ)
  @calendar_users = @room.users

  (Roomモデル）
  has_many :roommate_lists, dependent: :destroy
  has_many :users, through: :roommate_lists

  上記によって、コントローラの@room.usersではルームメイトに入っているuserだけの情報が回っている（招待０人時の、一人暮らし作成者userは入っていない)
```

- (解決法)userモデルに、招待していない時の作成者・招待後のルームメイト全員(作成者の重複のぞく)room_idごとに管理することを定義


同じ部屋に所属するユーザー全員
    def grouped_shared_users
      Room.where(id: owned_rooms.pluck(:id) + rooms.pluck(:id))
        .includes(:users)
        .each_with_object({}) do |room, hash|
          all_users = (room.users + [ room.user ]).uniq
          hash[room.id] = all_users
        end
    end
```

- コントローラで呼び出し

  `@calendar_users = current_user.grouped_shared_users[@room.id] || []
`
# できるようになったこと
- 誰も招待していない、一人暮らしuserがカレンダー一覧を開いたときにカレンダーが表示される

# 作業ブランチ
- feature27/fix_calendar_index2

# その他
「部屋ごとにユーザーや機能を独立させて表示する」という目的のため、沢山の場合分けが必要でした。
機能も増えてきたので、変数の定義を今一度確認しながら進めていく必要があります。
機能ごとに合わせた、部屋作成user/招待されたuserをroom_idごとに表示させるということを実装していくとき、「招待０の場合は？」「データが何もない初期状態の場合は？」というように
条件を細かく想定して実装する必要がありました。
変数に一貫性を持たせて、共通化できるところはなるべくそうするよう心掛けたいと思います。
  
