### PR TITLE
add/edit_delete_spot

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -21,12 +21,42 @@ class SpotsController < ApplicationController
     if @spot.save
         redirect_to room_spots_path(@room), notice: "場所を登録しました"
     else
-        redirect_to new_room_greeting_path(@room), alert: "場所の登録に失敗しました"
+        redirect_to new_room_spot_path(@room), alert: "場所の登録に失敗しました"
     end
   end
 
   def show
     @spot = Spot.find(params[:id])
+  end
+
+  def edit
+    @spot = @room.spots.find_by(user: current_user, id: params[:id])
+  end
+
+  def update
+    @room = Room.find(params[:room_id])
+    @spot = @room.spots.find_by(user: current_user, id: params[:id])
+
+    if @spot.update(spot_params)
+      redirect_to room_spots_path(@room), notice: "場所名を更新しました"
+    else
+      @spots = @room.spots.includes(:user).order(created_at: :desc)
+      flash.now[:alert] = "場所名の更新に失敗しました"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @room = Room.find(params[:room_id])
+    @spot = @room.spots.find_by(user: current_user, id: params[:id])
+
+    if @spot.destroy
+      redirect_to room_spots_path(@room), notice: "場所を削除しました"
+    else
+      @spots = @room.spots.includes(:user).order(created_at: :desc)
+      flash.now[:alert] = "場所の削除に失敗しました"
+      render :new, status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -20,7 +20,7 @@
         <div class="mb-4">
           <div class="flex justify-between items-center">
             <%= f.label :address, "住所または場所名 *(例)東京都 スカイツリー", class: "block text-dark-gray text-sm font-bold mb-2" %>
-            <button id="btn-search" class= "bg-yellow/50 hover:bg-yellow/30 text-gray font-bold py-2 px-6 rounded-xl transition duration-200", data: { turbo: false } %>➡検索</button>
+            <button id="btn-search" class= "bg-yellow/50 hover:bg-yellow/30 text-dark-gray font-bold py-2 px-6 rounded-xl transition duration-200", data: { turbo: false } %>➡検索</button>
           </div>
         <%= f.text_field :address, id: "address", class: "w-full px-4 py-2 bg-gray/50 text-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
         </div>

--- a/app/views/spots/edit.html.erb
+++ b/app/views/spots/edit.html.erb
@@ -1,0 +1,78 @@
+<%= content_for :spot, @spot.name %>
+
+<div class="container pt-5">
+    <div class="flex justify-center mb-3">
+    <div class="w-full max-w-2xl">
+        <div class="bg-white rounded-lg shadow-md">
+        <div class="p-6">
+            <div class="flex justify-between items-center mb-4">
+            <h3 class="text-2xl font-semibold text-green-600"><%= @spot.name %></h3>
+
+                <p class="text-sm text-gray-700">
+                <strong>場所ID:</strong> <%= @spot.id %><br>
+                <strong>ステータス:</strong> <%= @spot.visit_status %><br>
+                <strong>登録日時:</strong> <%= l(@spot.created_at, format: :long) %><br>
+                <strong>ユーザー:</strong> <%= @spot.user.name %>
+                <strong>住所:</strong> <%= @spot.address %>
+                </p>
+                <% if @spot.user == current_user %>
+                  <%= form_with model: [@room, @spot], local: true, id: 'post-form', class: "max-w-md mx-auto p-6 bg-light-gray rounded-2xl shadow-lg" do |f| %>
+                    <% if @spot.errors.any? %>
+                    <div class= "text-bold text-brown">
+                      <ul>
+                        <% @spot.errors.full_messages.each do |message| %>
+                            <li><%= message %></li>
+                        <% end %>
+                      </ul>
+                    </div>
+                    <% end %>
+                    <%= f.label :visit_status, "種類" %>
+                    <%= f.select :visit_status, Spot.visit_statuses.keys.map { |k| [k.titleize, k] } %>     
+                    <!-- 場所名入力 -->
+                    <div class="mb-4">
+                    <%= f.label :name, "場所の名前 *場所名は自動入力されますが、適宜変更してください", class: "block text-dark-gray text-sm font-bold mb-2" %>
+                    <%= f.text_field :name, id: "name", class: "w-full px-4 py-2 bg-gray/50 text-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
+                    </div>
+                    <div class="text-center">
+                        <%= f.submit "更新", class: "bg-light-blue text-dark-gray py-2 px-6 rounded hover:bg-light-blue/80 transition duration-200", data: { turbo: false } %>
+                    </div>
+                    <%= link_to '<i class="fa-solid fa-trash text-lg text-blue"></i>'.html_safe, [@room, @spot], data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？"} %>
+                  <% end %>
+                <% end %>
+            </div>
+        </div>
+        </div>
+    </div>
+    </div>
+</div>
+
+<div id="map" style="height: 400px; width: 100%; margin-top: 2rem;"></div>
+
+<script>
+  const lat = <%= @spot.latitude.to_f %>;
+  const lng = <%= @spot.longitude.to_f %>;
+  let map;
+
+  function initMap() {
+    map = new google.maps.Map(document.getElementById("map"), {
+      center: { lat: lat, lng: lng },
+      zoom: 12,
+      mapTypeId: "hybrid",
+      mapId: "<%= ENV['MAP_ID'] %>",
+    });
+
+    const marker = new google.maps.marker.AdvancedMarkerElement({
+      map: map,
+      position: {
+        lat: lat,
+        lng: lng
+      }
+    });
+
+    const geocoder = new google.maps.Geocoder();
+    const latLng = new google.maps.LatLng(lat, lng);
+  }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API'] %>&callback=initMap&libraries=marker&v=weekly&loading=async" async defer></script>
+
+<%= link_to "戻る", room_spots_path(@room) %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -1,11 +1,16 @@
 <% if @visited.present? %>
     <h2>visited一覧</h2>
-    <% @spots.visited.each do |spot| %>
+    <% @visited.each do |spot| %>
         <div class="flex">
+          <% if current_user == spot.user %>
+            <%= link_to spot.name, edit_room_spot_path(@room, spot) %>
+          <% else %>
             <%= link_to spot.name, room_spot_path(@room, spot) %>
+          <% end %>
             <%= spot.address %>
             <%= l(spot.created_at, format: :short) %>
-            <!--= link_to spot.visit_status, edit_room_spot_path(@room, spot) %>-->
+            <%= spot.visit_status %>
+            <%= spot.user.name %>
         </div>
     <% end %>
 <% else %>
@@ -14,12 +19,17 @@
 
 <% if @wanna_visit.present? %>
     <h2>wanna_visit一覧</h2>
-    <% @spots.wanna_visit.each do |spot| %>
+    <% @wanna_visit.each do |spot| %>
         <div class="flex">
+          <% if current_user == spot.user %>
+            <%= link_to spot.name, edit_room_spot_path(@room, spot) %>
+          <% else %>
             <%= link_to spot.name, room_spot_path(@room, spot) %>
+          <% end %>
             <%= spot.address %>
             <%= l(spot.created_at, format: :short) %>
-            <!--= link_to spot.visit_status, edit_room_spot_path(@room, spot) %>-->
+            <%= spot.visit_status %>
+            <%= spot.user.name %>
         </div>
     <% end %>
 <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     resources :state_calendars, only: %i[new create index update edit destroy]
     resources :invitation_tokens, only: %i[create index update]
     resources :greetings, only: %i[new create index edit update destroy]
-    resources :spots, only: %i[index new create show]
+    resources :spots, only: %i[index new create show edit update destroy]
   end
 
   resources :areas, only: %i[create update index]


### PR DESCRIPTION
# 「行ったことがある場所」「行きたい場所」登録後、編集・削除できるよう実装しました

- [x] ルーティングにedit, update, destroyを追記
- [x] コントローラにedit, update, destroyアクションを追記
- [x] ビューファイルにedit用のフォーム作成・編集
- [x] ビューファイルにゴミ箱マーク（font-awesome)とdelete追記
- [x] indexファイルのリンクに、editページへ飛ぶリンク付き文字を追記

# できること
- 登録場所の一覧から場所名をクリックしたとき
  - クリックした人が "その場所を登録した人" の場合はeditページに飛び、「場所名」「行ったことがある/行きたい」のステータスを変更できます。登録場所の削除もここで可能になります。
  - クリックした人が "その場所を登録した人ではない" 場合、showページに飛び詳細の閲覧のみ可能です。

# 作業ブランチ
- feature29/edit_delete_spot