### PR TITLE
fix/whiteboard_on_3droom

### DIFF
--- a/app/views/rooms/_board.html.erb
+++ b/app/views/rooms/_board.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-white shadow p-4 fixed top-[260px] left-4 w-[200px] h-[300px] overflow-y-auto">
+<div class="bg-white shadow z-50 p-4 fixed top-[260px] left-4 w-[200px] h-[300px] overflow-y-auto">
   <% if @whiteboards.empty? %>
     <p class="text-dark-gray text-center text-sm">伝言はまだありません</p>
   <% else %>
@@ -13,7 +13,7 @@
                 contenteditable="true"
                 class="whitespace-pre-wrap focus:outline-none min-h-[40px]"
             >
-            <%= h(@whiteboard&.body || "") %>
+            <%= h(board.body || "") %>
             </div>
         <% else %>
           <%= board.body %>

--- a/app/views/rooms/_form_board.html.erb
+++ b/app/views/rooms/_form_board.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-white shadow p-4 fixed top-[220px] right-4 w-[150px] h-[260px] overflow-y-auto">
+<div class="bg-white shadow z-50 p-4 fixed top-[220px] right-4 w-[150px] h-[260px] overflow-y-auto">
   <!-- ホワイトボード入力エリア -->
   <div
     data-controller="board"

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :main_class, "relative w-full flex flex-col mt-16 flex-1" %>
-<div class="fixed top-[px80] left-1/2 transform -translate-x-1/2 z-50 p-4">
+<div class="fixed top-[80px] left-1/2 transform -translate-x-1/2 z-50 p-4">
   <div class="text-matcha text-center text-2xl font-bold rounded-lg shadow-md p-4">
     <%= @room.name %><i class="fa-solid fa-house-user"></i>
   </div>


### PR DESCRIPTION
# ホワイトボードを３ｄ部屋上に表示しました

- classに`` z-50 `` の記述が抜けていたため、ホワイトボードが３ｄ部屋の下に隠れ、見えない状態でした。
- 上記の記述を追加し、解決しました。

# 作業ブランチ
- feature33/fix_whiteboard