### PR TITLE
add_3d_door

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container fixed top-[80px] left-1/2 transform -translate-x-1/2 z-50 p-4">
   <div class="flex justify-center">
     <div class="w-full max-w-lg">
       <h1 class="text-2xl text-brown font-bold mb-6">新規登録</h1> 
@@ -25,3 +25,75 @@
     </div>
   </div>
 </div>
+
+<div class="relative w-full h-[calc(100vh-112px)] overflow-hidden">
+  <canvas id="three-canvas" class="w-full h-full block"></canvas>
+</div>
+
+<script>
+  let mixer;
+  const clock = new THREE.Clock();
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+  const canvas   = document.getElementById('three-canvas');
+  const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+  renderer.setSize(window.innerWidth, window.innerHeight); // 実ピクセルで設定
+  renderer.setPixelRatio(window.devicePixelRatio);
+  scene.background = new THREE.Color('#F8F8F0');
+
+  const light = new THREE.DirectionalLight(0xffffff, 1);
+  light.position.set(10, 10, 10).normalize();
+  scene.add(light);
+
+  const ambientLight = new THREE.AmbientLight(0x404040, 1.5);
+  scene.add(ambientLight);
+
+  let dracoLoader = new THREE.DRACOLoader();
+  dracoLoader.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
+
+  let loader = new THREE.GLTFLoader();
+  loader.setDRACOLoader(dracoLoader);
+
+  loader.load('/door.glb', function (gltf) {
+  const model = gltf.scene;
+  console.log("モデルが読み込まれました:", model);
+  model.scale.set(0.8, 0.8, 0.8);
+
+  const box = new THREE.Box3().setFromObject(model);
+  const center = box.getCenter(new THREE.Vector3());
+
+  model.position.sub(center);
+  scene.add(model);
+}, undefined, function (error) {
+  console.error("モデルの読み込みに失敗しました:", error);
+});
+
+  camera.position.set(10, -5, 0);
+  camera.lookAt(0, 2, 0);
+
+  const controls = new THREE.OrbitControls(camera, renderer.domElement);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.05;
+  controls.screenSpacePanning = false;
+  controls.maxPolarAngle = Math.PI / 2;
+
+  function animate() {
+    requestAnimationFrame(animate);
+    controls.update();
+
+    const delta = clock.getDelta();
+    if (mixer) mixer.update(delta);
+
+    renderer.render(scene, camera);
+  }
+  animate();
+
+  window.addEventListener('resize', () => {
+    const width  = window.innerWidth;
+    const height = window.innerHeight;
+    renderer.setSize(width, height);
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+  });
+</script>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="container mx-auto px-4">
+<div class="container fixed top-[80px] left-1/2 transform -translate-x-1/2 z-50 p-4">
   <div class="flex justify-center">
     <div class="w-full max-w-lg">
       <h1 class="text-2xl text-green-400 font-bold mb-6">ログイン</h1>
@@ -12,9 +12,125 @@
           <%= f.label :password, class: "block text-sm font-medium text-green-400" %>
           <%= f.password_field :password, class: "mt-1 mb-6 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-green-400 focus:border-green-600 text-green-400" %>
         </div>
-        <%= f.submit 'ログインして帰宅', class: "w-full mb-6 bg-green-400 hover:bg-green-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition" %>
+        <%= f.submit 'ログインして帰宅', class: "w-full mb-6 bg-green-400 hover:bg-green-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition",
+        id: "blue-door" %>
         <% end %>
         <%= link_to '新規登録はこちら', new_user_registration_path, class: "text-green-600" %>
     </div>
   </div>
 </div>
+
+<div class="relative w-full h-[calc(100vh-112px)] overflow-hidden">
+  <canvas id="three-canvas" class="w-full h-full block"></canvas>
+</div>
+
+<script>
+  let mixer;
+  const clock = new THREE.Clock();
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+  const canvas   = document.getElementById('three-canvas');
+  const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+  renderer.setSize(window.innerWidth, window.innerHeight); // 実ピクセルで設定
+  renderer.setPixelRatio(window.devicePixelRatio);
+  scene.background = new THREE.Color('#F8F8F0');
+
+  const light = new THREE.DirectionalLight(0xffffff, 1);
+  light.position.set(10, 10, 10).normalize();
+  scene.add(light);
+
+  const ambientLight = new THREE.AmbientLight(0x404040, 1.5);
+  scene.add(ambientLight);
+
+  let dracoLoader = new THREE.DRACOLoader();
+  dracoLoader.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/');
+
+  let loader = new THREE.GLTFLoader();
+  loader.setDRACOLoader(dracoLoader);
+
+  loader.load('/door.glb', function (gltf) {
+  const model = gltf.scene;
+  console.log("モデルが読み込まれました:", model);
+  model.scale.set(0.8, 0.8, 0.8);
+
+  const box = new THREE.Box3().setFromObject(model);
+  const center = box.getCenter(new THREE.Vector3());
+
+  model.position.sub(center);
+  scene.add(model);
+
+  mixer = new THREE.AnimationMixer(model);
+  window.mixer = mixer;
+  window.doorAnimationClips = gltf.animations;
+
+  const doorBtn = document.getElementById("blue-door");
+if (doorBtn) {
+  doorBtn.addEventListener("click", (e) => {
+
+    const animationNames = [
+      "CubeAction.001"
+    ];
+
+    if (window.mixer && window.doorAnimationClips) {
+      let maxDuration = 0;
+
+      animationNames.forEach(name => {
+        const clip = window.doorAnimationClips.find(c => c.name === name);
+        if (clip) {
+          const action = window.mixer.clipAction(clip);
+          action.reset();
+          action.setLoop(THREE.LoopOnce, 1);
+          action.clampWhenFinished = true;
+          action.play();
+
+          // 一番長いdurationを取得
+          if (clip.duration > maxDuration) {
+            maxDuration = clip.duration;
+          }
+        }
+      });
+
+      // 全アニメーション終了後に遷移
+      setTimeout(() => {
+        doorBtn.closest("form").submit(); // ←ここでform送信
+      }, maxDuration * 1000);
+    } else {
+      // アニメーションがない場合はそのまま送信
+      doorBtn.closest("form").submit();
+    }
+  });
+}
+}, undefined, function (error) {
+  console.error("モデルの読み込みに失敗しました:", error);
+});
+
+  camera.position.set(10, -5, 0);
+  camera.lookAt(0, 2, 0);
+
+  const controls = new THREE.OrbitControls(camera, renderer.domElement);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.05;
+  controls.screenSpacePanning = false;
+  controls.maxPolarAngle = Math.PI / 2;
+
+  function animate() {
+    requestAnimationFrame(animate);
+    controls.update();
+
+    const delta = clock.getDelta();
+    if (mixer) mixer.update(delta);
+
+    renderer.render(scene, camera);
+  }
+  animate();
+
+  window.addEventListener('resize', () => {
+    const width  = window.innerWidth;
+    const height = window.innerHeight;
+    renderer.setSize(width, height);
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+  });
+</script>
+


### PR DESCRIPTION
# ログイン・新規登録画面にドアの3dモデル表示＆ログイン時にドアが開くアニメーション実装

- [x] ログインのとき、room/indexの背景をドアの3Dにする
- [x] ログイン、新規作成、room/index の各ボタンとフォームを３Dの上に固定
- [x] ログインを押した後「帰宅」を押すと、遷移前に玄関のドアが開くアニメション実行

# 作業ブランチ
- feature36/3d_door