### PR TITLE
Feature38/greetings display

### DIFF
--- a/app/controllers/greetings_controller.rb
+++ b/app/controllers/greetings_controller.rb
@@ -6,6 +6,7 @@ class GreetingsController < ApplicationController
     @greetings = @room.greetings.includes(:user).order(created_at: :desc)
     @welcome = @greetings.welcome
     @return = @greetings.return
+    @random_welcome = @welcome.sample if @welcome.present?
   end
 
   def new

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -42,6 +42,11 @@ class RoomsController < ApplicationController
     @greetings = @room.greetings.includes(:user).order(created_at: :desc)
     @welcome = @greetings.welcome
     @return = @greetings.return
+    @roommates_except_self = current_user.roommates_except_self
+
+    if params[:from_home_button]
+      flash[:just_signed_in] = true
+    end
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,4 +29,9 @@ class User < ApplicationRecord
         hash[room.id] = all_users
       end
   end
+  # 自分を除く、同じ部屋に属するユーザー全員
+  def roommates_except_self
+    grouped_shared_users.values.flatten.uniq.reject { |user| user == self }
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,5 +33,4 @@ class User < ApplicationRecord
   def roommates_except_self
     grouped_shared_users.values.flatten.uniq.reject { |user| user == self }
   end
-
 end

--- a/app/views/greetings/index.html.erb
+++ b/app/views/greetings/index.html.erb
@@ -26,3 +26,4 @@
 <% end %>
 
 <%= link_to "メッセージ作成", new_room_greeting_path() %>
+<%= link_to "#{@room.name}に戻る", room_path(@room) %>

--- a/app/views/invitation_tokens/index.html.erb
+++ b/app/views/invitation_tokens/index.html.erb
@@ -29,3 +29,4 @@
     <% end %>
   </tbody>
 </table>
+<%= link_to "#{@room.name}に戻る", room_path(@room) %>

--- a/app/views/rooms/_greeting.html.erb
+++ b/app/views/rooms/_greeting.html.erb
@@ -1,27 +1,42 @@
-<div class="fixed top-[600px] left-0 z-50 bg-blue/50 p-4 rounded-lg shadow-md justify-end">
-    <% if @return.present? %>
-        <% @greetings.return.each do |greeting| %>
-            <% if greeting.user == current_user %>
-                <div>
-                    <p><%= greeting.user.name %></p>
-                    <p><%= greeting.message %></p>
-                </div>
-            <% end %>
+<% if flash[:just_signed_in] %>
+  <div id="login-greeting">
+    <div class="fixed top-[630px] left-0 z-50 justify-end">
+      <% if @roommates_except_self.present? %>
+        <% if @random_welcome.present? %>
+            <p><%= @random_welcome.user.name %></p>
+            <p class= "bg-blue/50 p-4 rounded-lg shadow-md"><%= @random_return.message %></p>
+        <% else %>
+            <%= @roommates_except_self.sample.name %>
+            <p class= "bg-blue/50 p-4 rounded-lg shadow-md">おかえりなさい！</p>
         <% end %>
-    <% else %>
-        <h2>おかえりなさい</h2>
-    <% end %>
-
-    <% if @welcome.present? %>
-        <% @greetings.welcome.each do |greeting| %>
-            <% if greeting.user == current_user %>
-                <div>
-                    <p><%= greeting.user.name %></p>
-                    <p><%= greeting.message %></p>
-                </div>
+      <% else %>
+        <h2 class= "bg-blue/50 p-4 rounded-lg shadow-md">おかえりなさい</h2>
+      <% end %>
+    </div>
+    
+    <div class="fixed top-[560px] left-0 z-50 justify-end">
+        <% if @return.present? %>
+            <% @greetings.return.each do |greeting| %>
+                <% if greeting.user == current_user %>
+                    <div>
+                        <p><%= greeting.user.name %></p>
+                        <p class= "bg-matcha/50 p-4 rounded-lg shadow-md"><%= greeting.message %></p>
+                    </div>
+                <% end %>
             <% end %>
+        <% else %>
+            <h2>ただいま～！！</h2>
         <% end %>
-    <% else %>
-        <h2>ただいま～！！</h2>
-    <% end %>
-</div>
+    </div>
+  </div>
+    <script>
+    setTimeout(() => {
+      const box = document.getElementById('login-greeting');
+      if (box) {
+        box.style.transition = 'opacity 1s ease';
+        box.style.opacity = 0;
+        setTimeout(() => box.remove(), 1000);
+      }
+    }, 30000);
+  </script>
+<% end %>

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -31,7 +31,7 @@
         <% end %>
       <% end %>
         <div class= "text-right">
-          <%= link_to "この家に帰宅する", room_path(room), class: "bg-light-blue text-dark-gray px-4 py-2 mt-2 rounded hover:bg-light-blue/80 transition" %>
+          <%= link_to "この家に帰宅する", room_path(room, from_home_button: true), class: "bg-light-blue text-dark-gray px-4 py-2 mt-2 rounded hover:bg-light-blue/80 transition" %>
         </div>
     </div>
   <% end %>

--- a/app/views/rooms/_weather.html.erb
+++ b/app/views/rooms/_weather.html.erb
@@ -1,5 +1,5 @@
-<div class="fixed top-[120px] left-0 z-50 bg-white/90 p-4 rounded-lg shadow-md">
 <% if @roommates.present? %>
+  <div class="fixed top-[120px] left-0 z-50 bg-white/90 p-4 rounded-lg shadow-md">
   <% @roommates.each do |user| %>
     <div class="weather flex space-x-2 text-sm px-2 py-1 border border-light-gray rounded">
       <h3><%= user.name %></h3>
@@ -25,8 +25,10 @@
       <% end %>
     </div>
   <% end %>
+  </div>
 <% else %>
-  <div class="weather flex space-x-2 text-sm px-2 py-1 border border-light-gray rounded">
+  <div class="fixed top-[120px] left-0 z-50 bg-white/90 p-4 rounded-lg shadow-md">
+    <div class="weather flex space-x-2 text-sm px-2 py-1 border border-light-gray rounded">
     <h3><%= current_user.name %></h3>
 
     <% if current_user.area.nil? %>
@@ -39,7 +41,7 @@
       <% if weather_record.nil? %>
         <%= button_to "天気を取得する", weather_records_path(area_id: current_user.area.id, room_id: @room.id), method: :post, data: { turbo: false } %>
       <% else %>
-        <%= button_to "天気を更新する", weather_record_path(weather_record, area_id: current_user.area.id, room_id: @room.id), method: :patch, data: { turbo: false } %>
+        <%= button_to "天気を更新する", weather_record_path(weather_record, area_id: current_user.area.id, room_id: @room.id), method: :patch, data: { turbo: false }, class: "text-blue underline font-bold" %>
         <p>天気: <%= weather_record.description %></p>
         <p>気温：<%= weather_record.temperature %>℃</p>
         <% if weather_record.created_at == weather_record.updated_at %>
@@ -49,6 +51,6 @@
         <% end %>
       <% end %>
     <% end %>
+    </div>
   </div>
-</div>
 <% end %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -38,3 +38,4 @@
       <h2><i class="fa-solid fa-location-pin text-red-500"></i> まだ「行きたい場所」の登録はありません</h2>
   <% end %>
 </div>
+<%= link_to "#{@room.name}に戻る", room_path(@room) %>


### PR DESCRIPTION
# おかえりメッセージ表示機能（ルームメイトあり/なし条件分岐を実装しました
- [x] ルームメイトがいる且つおかえりメッセージが登録されている部屋の場合、ルームメイトの名前と登録された
「おかえりメッセージ」をランダム表示
- [x] ルームメイトがいて、おかえりメッセージが登録されていない場合はデフォルト「おかえり」メッセージ表示と自分以外のルームメイトの名前をランダム表示
- [x] ルームメイトがいない場合は、デフォルトのおかえりメッセージのみ表示

# 追加した点
- userモデルにて、「自分を含めた同じ部屋に属するルームメイト全員」を定義していましたが、今回は「自分を除くルームメイト全員」を取得したかったため ``user.rb`` に以下の記述を追加
```
# 自分を除く、同じ部屋に属するユーザー全員
  def roommates_except_self
    grouped_shared_users.values.flatten.uniq.reject { |user| user == self }
  end
```
- ビューファイルで使うために、roomコントローラに記述を追加
```
@roommates_except_self = current_user.roommates_except_self
```

# 作業ブランチ
- feature38/greetings_display