### PR TITLE
feature39/fix_greetings_display

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -42,7 +42,7 @@ class RoomsController < ApplicationController
     @greetings = @room.greetings.includes(:user).order(created_at: :desc)
     @welcome = @greetings.welcome
     @return = @greetings.return
-    @roommates_except_self = current_user.roommates_except_self
+    @roommates_except_self = current_user.roommates_except_self(@room)
 
     if params[:from_home_button]
       flash[:just_signed_in] = true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User < ApplicationRecord
       end
   end
   # 自分を除く、同じ部屋に属するユーザー全員
-  def roommates_except_self
-    grouped_shared_users.values.flatten.uniq.reject { |user| user == self }
+  def roommates_except_self(room)
+    (room.users + [ room.user ]).uniq.reject { |user| user == self }
   end
 end

--- a/app/views/rooms/_greeting.html.erb
+++ b/app/views/rooms/_greeting.html.erb
@@ -10,7 +10,18 @@
             <p class= "bg-blue/50 p-4 rounded-lg shadow-md">おかえりなさい！</p>
         <% end %>
       <% else %>
+        <% if @welcome.present? %>
+            <% @greetings.welcome.each do |greeting| %>
+                <% if greeting.user == current_user %>
+                    <div>
+                        <p><%= greeting.user.name %></p>
+                        <p class= "bg-blue/50 p-4 rounded-lg shadow-md"><%= greeting.message %></p>
+                    </div>
+                <% end %>
+            <% end %>
+        <% else %>
         <h2 class= "bg-blue/50 p-4 rounded-lg shadow-md">おかえりなさい</h2>
+        <% end %>
       <% end %>
     </div>
     
@@ -25,7 +36,7 @@
                 <% end %>
             <% end %>
         <% else %>
-            <h2>ただいま～！！</h2>
+            <h2 class= "bg-matcha/50 p-4 rounded-lg shadow-md">ただいま～！！</h2>
         <% end %>
     </div>
   </div>


### PR DESCRIPTION
# 「自分以外のルームメイト全員」の定義を修正
- [x] ルームメイトがいない、且つおかえりメッセージを登録したときに、登録メッセージと自分の名前を表示
- [x] user.rbの定義を以下のように修正
```
# 自分を除く、同じ部屋に属するユーザー全員
  def roommates_except_self(room)
    (room.users + [room.user]).uniq.reject { |user| user == self }
  end
```
# 作業ブランチ
- feature39/fix_greetings_display

# その他
- 元のコード(これでは、grouped_shared_usersの定義が渡っておらず、room_idごとに分けている状態を引き継いでいない）
```
# 自分を除く、同じ部屋に属するユーザー全員
  def roommates_except_self
    grouped_shared_users.values.flatten.uniq.reject { |user| user == self }
  end
```
- 修正コード⓵シンプルにroom_idごとに分ける旨を記述
```
# 自分を除く、同じ部屋に属するユーザー全員
  def roommates_except_self(room)
    (room.users + [room.user]).uniq.reject { |user| user == self }
  end
```
- 修正コード⓶grouped_shared_usersのroom_idごとに分けている定義を引き継ぐ記述追加（transform_values)
```
def grouped_roommates_except_self
  grouped_shared_users.transform_values do |users|
    users.reject { |user| user == self }
  end
end
```
