### PR TITLE
add/invitation_token_css

### DIFF
--- a/app/controllers/invitation_tokens_controller.rb
+++ b/app/controllers/invitation_tokens_controller.rb
@@ -5,10 +5,12 @@ class InvitationTokensController < ApplicationController
   def index
     @room = Room.find(params[:room_id])
     if @room.user_id == current_user.id
-        @invitation_tokens = @room.invitation_tokens.order(created_at: :desc)
+        @invitation_tokens = @room.invitation_tokens.distinct.order(created_at: :desc)
     else
-        redirect_to root_path, alert: "自分の部屋のトークンしか表示できません"
+        redirect_to root_path, alert: "自分が作成した部屋のトークンしか表示できません"
+        return
     end
+    @valid_tokens = @invitation_tokens.select { |token| token.used_at.nil? && token.expires_at > Time.current }
   end
 
   def create

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./controllers/copy"

--- a/app/javascript/controllers/copy.js
+++ b/app/javascript/controllers/copy.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.copy-button').forEach(button => {
+    button.addEventListener('click', () => {
+      const url = button.getAttribute('data-url');
+      if (!url) return;
+
+      navigator.clipboard.writeText(url)
+        .then(() => {
+          const originalText = button.querySelector('.copy-text');
+          originalText.textContent = 'コピーしました';
+          setTimeout(() => {
+            originalText.textContent = 'コピー';
+          }, 2000);
+        })
+        .catch(error => {
+          console.error('コピー失敗:', error);
+        });
+    });
+  });
+});

--- a/app/views/invitation_tokens/index.html.erb
+++ b/app/views/invitation_tokens/index.html.erb
@@ -1,32 +1,65 @@
-<h2>招待トークン一覧</h2>
+<div class="container bg-light-gray/50">
+  <div class="text-center">
+  <% if @valid_tokens.present? %>
+    <% @valid_tokens.each do |token| %>
+        <div class="flex justify-center items-center my-2 space-x-4">
+          <!-- 招待リンクを表示 -->
+          <div id="post_<%= token.id %>" class="inline-block">
+            <%= link_to "招待リンク", join_roommate_lists_url(token: token.token), target: "_blank", class: "text-blue-600 underline" %>
+            <h1>有効期限：<%= l(token.expires_at, format: :short) %></h1>
+            <h1>トークン番号:No.<%= token.id %></h1>
+          </div>
 
-<%= form_with url: room_invitation_tokens_path(@room), method: :post, local: true, data: { turbo: false } do |f| %>
-  <%= f.submit "トークンを発行する", class: "btn btn-primary" %>
-<% end %>
-
-<table>
-  <thead>
-    <tr>
-      <th>トークン</th>
-      <th>有効期限</th>
-      <th>使用済み？</th>
-      <th>発行日</th>
-      <th>使用日</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @invitation_tokens.each do |token| %>
-      <tr>
-        <td><%= token.token %></td>
-        <td>
-          <%= link_to "招待リンク", join_roommate_lists_url(token: token.token), target: "_blank" %>
-        </td>
-        <td><%= l(token.expires_at, format: :short) %></td>
-        <td><%= token.used_at.present? ? "はい" : "いいえ" %></td>
-        <td><%= l(token.created_at, format: :short) %></td>
-        <td><%= token.used_at ? l(token.used_at, format: :short) : "-" %></td>
-      </tr>
+          <!-- コピー用ボタン -->
+          <div class="float-right ml-2">
+            <button
+              class="copy-button btn btn-outline-secondary btn-sm"
+              data-url="<%= join_roommate_lists_url(token: token.token) %>"
+            >
+              <i class="far fa-copy mr-1"></i>
+              <span class="copy-text">コピー</span>
+            </button>
+          </div>
+        </div>
     <% end %>
-  </tbody>
-</table>
+  <% else %>
+        <h1>使用可能なトークンは現在ありません。新しくトークンを発行してください。</h1>
+  <% end %>
+
+    <!-- トークン発行フォーム -->
+    <%= form_with url: room_invitation_tokens_path(@room), method: :post, local: true, data: { turbo: false } do |f| %>
+      <%= f.submit "トークンを発行する", class: "bg-light-blue text-dark-gray px-4 py-2 mt-2 rounded hover:bg-light-blue/80 transition" %>
+    <% end %>
+  </div>
+</div>
+
+<h2>招待トークン一覧</h2>
+<div class="container bg-light-gray/50">
+  <div class="flex justify-center items-center my-2 space-x-4">
+    <table>
+      <thead>
+        <tr>
+          <th>トークン番号</th>
+          <th>有効期限</th>
+          <th>使用済み？</th>
+          <th>発行日</th>
+          <th>使用日</th>
+          <th>期限</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @invitation_tokens.each do |token| %>
+          <tr>
+            <td>No.<%= token.id %></td>
+            <td><%= l(token.expires_at, format: :short) %></td>
+            <td><%= token.used_at.present? ? "使用済" : "未使用" %></td>
+            <td><%= l(token.created_at, format: :short) %></td>
+            <td><%= token.used_at ? l(token.used_at, format: :short) : "-" %></td>
+            <td><%= token.expires_at < Time.current ? "期限切れ" : "期限内" %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
 <%= link_to "#{@room.name}に戻る", room_path(@room) %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -11,10 +11,12 @@
     style: "position:fixed;top:170px;right:10px;z-index:9999;" 
 %>
 <!--%= render 'calendar' %>-->
-<%= link_to "同居人を招待する", room_invitation_tokens_path(@room),
-    class: "btn-invitation inline-block px-2 py-2 bg-matcha/75 text-dark-gray rounded hover:bg-matcha/30 transition",
-    style: "position:fixed;top:70px;left:10px;z-index:9999;"
-%>
+<% if @room.user_id == current_user.id %>
+    <%= link_to "同居人を招待する", room_invitation_tokens_path(@room),
+        class: "btn-invitation inline-block px-2 py-2 bg-matcha/75 text-dark-gray rounded hover:bg-matcha/30 transition",
+        style: "position:fixed;top:70px;left:10px;z-index:9999;"
+    %>
+<% end %>
 
 <%= render 'greeting' %>
 <%= link_to "交換日記", room_exchange_diaries_path(@room),


### PR DESCRIPTION
# invitation_tokenのCSS調整、表示追加
- [x] invitation_tokenページのCSS調整
- [x] urlのコピー機能
- [x] トークンが期限切れか期限内か表示
- [x] トークンが有効期限内かつ未使用のものだけurlをコピーできる機能
- [x] 自分が作成した部屋だけに、招待リンク生成ページへのリンクが表示されるよう制限

# できること
- ログインしてから、検索ボックスにトークン付きurlをペーストして検索すると、招待された部屋に直接遷移し「ルームに参加しました」というメッセージが表示されます。

# できないこと
- ログイン前・新規登録前にurlを踏むと、ログインページに飛び、トークン付きurlの情報が消えます

# 作業ブランチ
- feature40/invitation_token_css