### PR TITLE
add/spot_search_input

### DIFF
--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -15,7 +15,7 @@
         class: "bg-dark-gray/75 text-white py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha" %>
         <div class="mb-4">
         <%= f.label :name, "場所の名前 *場所名は自動入力されますが、適宜変更してください", class: "block text-dark-gray text-sm font-bold mb-2" %>
-        <%= f.text_field :name, id: "name", class: "w-full px-4 py-2 bg-light-gray/75 text-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
+        <%= f.text_field :name, id: "name", class: "w-full px-4 py-2 bg-light-gray/75 text-matcha rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
         </div>
 
         <div class="mb-4">
@@ -23,7 +23,7 @@
             <%= f.label :address, "住所または場所名 *(例)東京都 スカイツリー", class: "block text-dark-gray text-sm font-bold mb-2" %>
             <button id="btn-search" class= "bg-blue/75 hover:bg-blue/30 text-dark-gray font-bold py-2 px-6 rounded-xl transition duration-200", data: { turbo: false } %>➡検索</button>
           </div>
-        <%= f.text_field :address, id: "address", class: "w-full px-4 py-2 bg-light-gray/75 text-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
+        <%= f.text_field :address, placeholder: "場所名を入力", id: "address", class: "w-full px-4 py-2 bg-light-gray/75 text-matcha rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
         </div>
         <div class="text-right">
         <%= link_to 'リセット', new_room_spot_path(@room), method: :get, class: "text-matcha" %>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -6,6 +6,7 @@
     const addressInput = document.getElementById("address");
     const placeNameInput = document.getElementById("fav_name");
     const searchBtn = document.getElementById("btn-search");
+    const nameInput = document.getElementById("name");
 
     map = new google.maps.Map(document.getElementById("map"), {
             center: { lat: 35.681236, lng: 139.767125 }, // 東京駅初期値
@@ -17,11 +18,22 @@
 
     searchBtn.addEventListener("click", async function (e) {
       e.preventDefault();
-      const query = addressInput.value;
-      if (!query) return;
+
+      const typedAddress = addressInput.value.trim();
+
+      // 最後の単語を取り出す（全角・半角スペース両対応）
+      const lastWord = typedAddress.split(/[\s　]+/).pop();
+
+      // name が空欄なら、lastWord をセット
+      if (nameInput.value.trim() === "") {
+        nameInput.value = lastWord;
+      }
+
+      // 入力が空なら中断
+      if (!typedAddress) return;
 
       // Geocoding API リクエスト
-      const geocodeUrl = `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(query)}&key=<%= ENV['GOOGLE_MAPS_API'] %>`;
+      const geocodeUrl = `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(typedAddress)}&key=<%= ENV['GOOGLE_MAPS_API'] %>`;
       const response = await fetch(geocodeUrl);
       const data = await response.json();
 


### PR DESCRIPTION
# spot登録画面での調整
- [x] 場所名の自動入力
- [x] 住所入力欄のplace holderに「場所名を入力」の文字を入れる
- [x] 住所入力後、「検索」を押したときの入力値の最後の単語を場所名の入力欄に自動input

# できるようになったこと
- 住所入力欄に「東京都　スカイツリー」と入力し、検索ボタンを押すと下記の２つの機能が動きます。
  - 全角・半角スペースで区切った最後の単語を場所名の入力欄に自動inputされます。
  - 検索されたときの場所名を使って、geocoderAPIで住所を補完し住所入力欄に自動inputします。

# 作業ブランチ
- feature41/spot_search_holder