### PR TITLE
adjust_css

### DIFF
--- a/app/controllers/areas_controller.rb
+++ b/app/controllers/areas_controller.rb
@@ -3,19 +3,7 @@ require "uri"
 require "json"
 class AreasController < ApplicationController
   before_action :set_area, only: [ :update ]
-
-  def index
-    api_key = ENV["WEATHER_API"]
-    city = "madagascar"
-    url = URI("https://api.openweathermap.org/data/2.5/weather?q=#{city}&appid=#{api_key}&units=metric&lang=ja")
-
-    response = Net::HTTP.get_response(url)
-    weather_data = JSON.parse(response.body)
-
-    Rails.logger.debug(weather_data)
-
-    @weather_data = weather_data
-  end
+  before_action :authenticate_user!
 
   def create
     @area = current_user.build_area(area_params)
@@ -23,7 +11,7 @@ class AreasController < ApplicationController
     if save_area_weather!(@area)
       redirect_to rooms_path, notice: "地域を登録しました"
     else
-      redirect_to areas_path, alert: "天気情報を取得できない都市名です。都市名をご確認ください。"
+      redirect_to rooms_path, alert: "天気情報を取得できない都市名です。都市名をご確認ください。"
     end
   end
 
@@ -32,7 +20,7 @@ class AreasController < ApplicationController
     if save_area_weather!(@area)
       redirect_to rooms_path, notice: "お住まいの地域を更新しました"
     else
-      redirect_to root_path, alert: "地域の変更に失敗しました"
+      redirect_to rooms_path, alert: "地域の変更に失敗しました"
     end
   end
 

--- a/app/controllers/exchange_diaries_controller.rb
+++ b/app/controllers/exchange_diaries_controller.rb
@@ -9,6 +9,7 @@ class ExchangeDiariesController < ApplicationController
     @exchange_diary = current_user.exchange_diaries.new
     @diary_count = @exchange_diaries.count
     @diary_order = @room.exchange_diaries.order(:created_at).pluck(:id)
+    @roommates = current_user.grouped_shared_users[@room.id] || []
 
     respond_to do |format|
       format.html

--- a/app/controllers/roommate_lists_controller.rb
+++ b/app/controllers/roommate_lists_controller.rb
@@ -7,17 +7,26 @@ class RoommateListsController < ApplicationController
         redirect_to root_path, alert: "招待リンクが存在しません"
         return
     end
+
     if token.expires_at < Time.current
         redirect_to root_path, alert: "招待リンクの有効期限が切れています"
         return
     end
-    if token.used_at.present?  # または token.used == true ならそれに合わせて
+
+    if token.used_at.present?
         redirect_to root_path, alert: "この招待リンクはすでに使用されています"
         return
     end
+
+    if RoommateList.exists?(user_id: current_user.id, room_id: token.room_id)
+      redirect_to root_path, alert: "すでにこのルームに参加しています"
+      return
+    end
+
     unless RoommateList.exists?(user_id: current_user.id, room_id: token.room_id)
         RoommateList.create!(user_id: current_user.id, room_id: token.room_id)
     end
+
     unless RoommateList.exists?(user_id: token.user_id, room_id: token.room_id)
         RoommateList.create!(user_id: token.user_id, room_id: token.room_id)
     end

--- a/app/views/exchange_diaries/_exchange_diary.html.erb
+++ b/app/views/exchange_diaries/_exchange_diary.html.erb
@@ -1,9 +1,8 @@
-<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+<div class="gap-6">
   <div class="bg-light-gray/75 p-4 my-4 rounded shadow text-dark-gray">
     <p class="mt-2 text-gray"><%= @diary_order.index(diary.id) + 1 %>日記目</p>
     <div class="text-sm"><%= diary.created_at.strftime("%y年%m月%d日") %></div>
     <% if diary.user == current_user %>
-      <!-- 非同期編集可能エリア -->
       <div
         data-controller="diary"
         data-diary-room-id-value="<%= @room.id %>"
@@ -11,20 +10,18 @@
         data-diary-target="diary"
         data-action="input->diary#save"
         contenteditable="true"
-        class="min-h-[100px] whitespace-pre-wrap focus:outline-none border rounded p-2 bg-white"
+        class="min-h-[100px] whitespace-pre-wrap focus:outline-none rounded p-2 bg-beige"
       >
         <%= h(diary.body) %>
       </div>
-      <p>diary.id: <%= diary.id.inspect %></p>
 
       <div class="flex justify-end mt-2 gap-x-2">
         <div class="text-sm"><%= diary.user.name %></div>
         <div>
-          <%= link_to '<i class="fa-solid fa-eraser text-xl"></i>'.html_safe, room_exchange_diary_path(@room, diary), data: { turbo_method: :delete, turbo_confirm: "本当に日記を消しますか？" } %>
+          <%= link_to '<i class="fa-solid fa-eraser text-xl"></i>'.html_safe, room_exchange_diary_path(@room, diary), data: { turbo_method: :delete, turbo_confirm: "本当に日記を削除しますか？" } %>
         </div>
       </div>
     <% else %>
-      <!-- 通常表示 -->
       <p class="mt-2"><%= diary.body %></p>
       <div class="text-right mt-2 text-sm"><%= diary.user.name %></div>
     <% end %>

--- a/app/views/exchange_diaries/_form.html.erb
+++ b/app/views/exchange_diaries/_form.html.erb
@@ -10,7 +10,7 @@
   <% end %>  
   <div class="bg-light-gray/75 p-4 rounded shadow mb-4">
     <div class="text-sm text-dark-gray"><%= Time.current.strftime("%y年%m月%d日") %></div>
-    <%= f.text_area :body, placeholder: "今日の出来事は？", rows: 5, class: "w-full p-2 mt-2 rounded text-dark-gray" %>
+    <%= f.text_area :body, placeholder: "今日の出来事は？", rows: 5, class: "w-full p-2 mt-2 rounded text-dark-gray bg-beige" %>
     <div class="flex justify-center">
       <%= f.submit @exchange_diary.persisted? ? "更新" : "日記を書く", class: "bg-light-blue text-dark-gray px-4 py-2 mt-2 rounded hover:bg-light-blue/80 transition" %>
     </div>

--- a/app/views/exchange_diaries/index.html.erb
+++ b/app/views/exchange_diaries/index.html.erb
@@ -1,3 +1,9 @@
+<div class="flex text-matcha text-xl font-bold rounded-lg shadow-md p-4">
+  <% @roommates.each do |roommate| %>
+    <%= roommate.name %>
+  <% end %>
+  <h1>の交換日記<i class="fa-solid fa-book"></i></h1>
+</div>
 <div class="container mx-auto px-4">
   <div class="max-w-xl mx-auto">
     <% @exchange_diaries.each do |diary| %>
@@ -7,16 +13,16 @@
       <%= render 'form' %>
     <% end %>
 
-    <!-- 新規追加ボタン -->
     <div class="text-center mt-4">
       <%= button_to '<i class="fa-solid fa-plus text-gray/50"></i>'.html_safe, room_exchange_diaries_path(@room), id: "show-form-button", method: :post, class: "text-3xl" %>
     </div>
 
-    <!-- 新規日記フォーム -->
     <div id="diary-form" class="hidden mt-4">
       <%= render 'form' %>
     </div>
   </div>
-  <%= paginate @exchange_diaries %>
+  <div class="text-center text-md font-bold text-matcha">
+    <%= paginate @exchange_diaries %>
+  </div>
 </div>
-<%= link_to "#{@room.name}に戻る", room_path(@room) %>
+<%= link_to "#{@room.name}🏠に戻る", room_path(@room), class: "bg-brown/30 p-2 rounded shadow mb-2 mt-4 text-brown font-bold hover:bg-brown/70 transition" %>

--- a/app/views/greetings/index.html.erb
+++ b/app/views/greetings/index.html.erb
@@ -1,29 +1,32 @@
-
-<% if @return.present? %>
-    <h2>ただいまメッセージ一覧</h2>
-    <% @greetings.return.each do |greeting| %>
-        <% if greeting.user == current_user %>
-        <div class="flex">
-            <%= l(greeting.created_at, format: :short) %>
-            <%= link_to greeting.message, edit_room_greeting_path(@room, greeting) %>
-        </div>
+<h1 class="text-dark-gray font-bold"><%= current_user.name %>さんの "<%= @room.name %>" 用のメッセージ管理画面</h1>
+<%= link_to "新規メッセージ作成", new_room_greeting_path(), class: "bg-blue/75 p-4 rounded shadow mb-4 mt-2 hover:bg-blue-30 transition text-dark-gray" %>
+<div class="w-full max-w-md mx-auto bg-light-gray/40 p-6 rounded-lg shadow-lg mt-4">
+    <% if @return.present? %>
+        <h2 class="text-matcha font-bold">ただいまメッセージ一覧</h2>
+        <% @greetings.return.each do |greeting| %>
+            <% if greeting.user == current_user %>
+            <div class="flex text-dark-gray">
+                <%= l(greeting.created_at, format: :short) %>
+                <h1>「<%= link_to greeting.message, edit_room_greeting_path(@room, greeting) %>」</h1>
+            </div>
+            <% end %>
         <% end %>
+    <% else %>
+        <h2 class="text-gray">※「ただいまメッセージ」の登録はまだありません</h2>
     <% end %>
-<% else %>
-    <h2>「おかえりメッセージ」の登録はまだありません</h2>
-<% end %>
+</div>
 
-<% if @welcome.present? %>
-    <h2>おかえりメッセージ一覧</h2>
-    <% @greetings.welcome.each do |greeting| %>
-        <div class="flex">
-            <%= l(greeting.created_at, format: :short) %>
-            <%= link_to greeting.message, edit_room_greeting_path(@room, greeting) %>
-        </div>
+<div class="w-full max-w-md mx-auto bg-light-gray/40 p-6 rounded-lg shadow-lg mt-4">
+    <% if @welcome.present? %>
+        <h2 class="text-matcha font-bold">おかえりメッセージ一覧</h2>
+        <% @greetings.welcome.each do |greeting| %>
+            <div class="flex text-dark-gray">
+                <%= l(greeting.created_at, format: :short) %>
+                <h1>「<%= link_to greeting.message, edit_room_greeting_path(@room, greeting) %>」</h1>
+            </div>
+        <% end %>
+    <% else %>
+        <h2 class="text-gray">※「おかえりメッセージ」の登録はまだありません</h2>
     <% end %>
-<% else %>
-    <h2>「ただいまメッセージ」の登録はまだありません</h2>
-<% end %>
-
-<%= link_to "メッセージ作成", new_room_greeting_path() %>
-<%= link_to "#{@room.name}に戻る", room_path(@room) %>
+</div>
+<%= link_to "#{@room.name}🏠に戻る", room_path(@room), class: "bg-brown/30 p-2 rounded shadow mb-2 mt-4 text-brown font-bold hover:bg-brown/70 transition" %>

--- a/app/views/greetings/new.html.erb
+++ b/app/views/greetings/new.html.erb
@@ -1,11 +1,24 @@
-<%= form_with model: [@room, Greeting.new], local: true do |f| %>
-  <%= f.label :message, "メッセージ" %>
-  <%= f.text_field :message %>
+<div class="mb-6">
+  <div class="text-dark-gray">
+    <h1>*登録された「おかえりメッセージ」➡ 招待後、相手ユーザーのログイン後画面に
+  ランダムで表示されます。</h1>
+    <h1>*登録された「ただいまメッセージ」➡ 自身のログイン後画面に
+  ランダムで表示されます。</h1>
+  </div>
+    <%= form_with model: [@room, Greeting.new], local: true, class: "max-w-md mx-auto p-6 bg-light-gray/50 rounded-2xl shadow-lg mt-2" do |f| %>
 
-  <%= f.label :greeting_type, "種類" %>
-  <%= f.select :greeting_type, Greeting.greeting_types.keys.map { |k| [k.titleize, k] } %>
+      <%= f.label :greeting_type, "ステータス", class: "text-dark-gray" %>
+      <%= f.select :greeting_type,
+          [["おかえりメッセージ", "welcome"], ["ただいまメッセージ", "return"]],
+          { prompt: "ただいま/おかえりを選択" }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha" %>
 
-  <%= f.submit "保存", style: "padding: 10px 20px; background-color: #ccc;" %>
-<% end %>
+      <%= f.label :message, "メッセージ", class: "text-dark-gray" %>
+      <%= f.text_field :message, placeholder: "メッセージを入力", class: "w-full px-4 py-2 bg-light-gray/75 text-matcha rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
+      <div class="text-center">
+        <%= f.submit "保存", class: "bg-blue/75 text-dark-gray py-2 px-6 rounded hover:bg-blue/30 transition duration-200 mt-2", data: { turbo: false } %>
+      </div>
+    <% end %>
+  </div>
+</div>
 
-<%= link_to "戻る", room_greetings_path(@room) %>
+<%= link_to "メッセージ一覧", room_greetings_path(@room), class: "bg-light-gray/75 py-2 px-6 rounded shadow mb-4 hover:bg-light-gray/50 transition text-dark-gray" %>

--- a/app/views/invitation_tokens/index.html.erb
+++ b/app/views/invitation_tokens/index.html.erb
@@ -1,47 +1,56 @@
-<div class="container bg-light-gray/50">
+<div class="max-w-lg mx-auto p-6 bg-light-gray/50 rounded-2xl shadow-lg mt-2">
   <div class="text-center">
+  <h1 class="text-dark-gray font-bold">現在有効な招待リンク一覧</h1>
   <% if @valid_tokens.present? %>
     <% @valid_tokens.each do |token| %>
-        <div class="flex justify-center items-center my-2 space-x-4">
+      <div class="bg-beige p-4 rounded shadow mb-4">
+        <div class="flex justify-center">
           <!-- 招待リンクを表示 -->
           <div id="post_<%= token.id %>" class="inline-block">
-            <%= link_to "招待リンク", join_roommate_lists_url(token: token.token), target: "_blank", class: "text-blue-600 underline" %>
-            <h1>有効期限：<%= l(token.expires_at, format: :short) %></h1>
-            <h1>トークン番号:No.<%= token.id %></h1>
+            <%= link_to "招待リンク", join_roommate_lists_url(token: token.token), target: "_blank", class: "text-brown" %>
+            <h1 class="text-matcha font-semibold">有効期限：<%= l(token.expires_at, format: :short) %></h1>
+            <h1 class="text-matcha font-semibold">トークン番号:No.<%= token.id %></h1>
           </div>
 
           <!-- コピー用ボタン -->
-          <div class="float-right ml-2">
+          <div class="float-right ml-2 text-brown">
             <button
               class="copy-button btn btn-outline-secondary btn-sm"
               data-url="<%= join_roommate_lists_url(token: token.token) %>"
             >
               <i class="far fa-copy mr-1"></i>
-              <span class="copy-text">コピー</span>
+              <span class="copy-text font-bold">コピー</span>
             </button>
           </div>
         </div>
+      </div>
     <% end %>
   <% else %>
-        <h1>使用可能なトークンは現在ありません。新しくトークンを発行してください。</h1>
+        <h1 class="text-matcha font-bold">使用可能なトークンは現在ありません。<br>
+        新しくトークンを発行してください。</h1>
   <% end %>
 
     <!-- トークン発行フォーム -->
     <%= form_with url: room_invitation_tokens_path(@room), method: :post, local: true, data: { turbo: false } do |f| %>
-      <%= f.submit "トークンを発行する", class: "bg-light-blue text-dark-gray px-4 py-2 mt-2 rounded hover:bg-light-blue/80 transition" %>
+      <%= f.submit "+ トークンを発行する", class: "bg-light-blue text-dark-gray px-4 py-2 mt-2 rounded hover:bg-light-blue/80 transition" %>
     <% end %>
+    <div class="text-dark-gray mt-2">
+      <p>※有効期限は発行後30分です。上記リンクをコピーして共有しましょう。</p>
+      <p>※お相手ユーザーがログイン後➡ 上記リンクを開くと部屋に招待されます。</p>
+      <p class="underline">※お相手ユーザーが新規登録・ログインしている必要があります。</p>
+    </div>
   </div>
 </div>
 
-<h2>招待トークン一覧</h2>
-<div class="container bg-light-gray/50">
+<div class="max-w-lg mx-auto p-6 bg-light-gray/50 rounded-2xl shadow-lg mt-4">
+  <h2 class="text-center text-dark-gray font-bold">招待トークン発行履歴</h2>
   <div class="flex justify-center items-center my-2 space-x-4">
     <table>
       <thead>
         <tr>
-          <th>トークン番号</th>
+          <th>番号</th>
           <th>有効期限</th>
-          <th>使用済み？</th>
+          <th>使用状況</th>
           <th>発行日</th>
           <th>使用日</th>
           <th>期限</th>
@@ -52,14 +61,26 @@
           <tr>
             <td>No.<%= token.id %></td>
             <td><%= l(token.expires_at, format: :short) %></td>
-            <td><%= token.used_at.present? ? "使用済" : "未使用" %></td>
+            <td>
+              <% if token.used_at.present? %>
+                <span class="text-blue font-semibold">使用済</span>
+              <% else %>
+                <span class="text-matcha font-semibold">未使用</span>
+              <% end %>
+            </td>
             <td><%= l(token.created_at, format: :short) %></td>
             <td><%= token.used_at ? l(token.used_at, format: :short) : "-" %></td>
-            <td><%= token.expires_at < Time.current ? "期限切れ" : "期限内" %></td>
+            <td>
+              <% if token.expires_at < Time.current %>
+                <span class="text-blue font-semibold">期限✕</span>
+              <% else %>
+                <span class="text-matcha font-semibold">期限〇</span>
+              <% end %>
+            </td>
           </tr>
         <% end %>
       </tbody>
     </table>
   </div>
 </div>
-<%= link_to "#{@room.name}に戻る", room_path(@room) %>
+<%= link_to "#{@room.name}🏠に戻る", room_path(@room), class: "bg-brown/30 p-2 rounded shadow mb-2 mt-4 text-brown font-bold hover:bg-brown/70 transition" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,13 +9,6 @@
 
     <%= yield :head %>
 
-    <% flash.each do |key, message| %>
-      <% text_color = key == "notice" ? "text-matcha" : "text-red-500" %>
-      <div class="flash <%= key %> <%= text_color %> font-semibold">
-        <%= message %>
-      </div>
-    <% end %>
-
     <link rel="manifest" href="/manifest.json">
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
@@ -40,6 +33,12 @@
       <%= render 'shared/header' %>
     <% else %>
       <%= render 'shared/before_login_header' %>
+    <% end %>
+    <% flash.each do |key, message| %>
+      <% text_color = key == "notice" ? "text-matcha" : "text-red-500" %>
+      <div class="flash <%= key %> <%= text_color %> font-semibold">
+        <%= message %>
+      </div>
     <% end %>
     <main class="flex-1 <%= content_for?(:main_class) ? yield(:main_class) : 'container mx-auto flex-1 flex flex-col justify-center items-center mt-16' %>">
       <%= yield %>

--- a/app/views/rooms/_board.html.erb
+++ b/app/views/rooms/_board.html.erb
@@ -11,6 +11,7 @@
                 data-board-target="board"
                 data-action="keydown->board#insertBreak input->board#save"
                 contenteditable="true"
+                data-placeholder="ここに入力してください"
                 class="whitespace-pre-wrap focus:outline-none min-h-[40px]"
             >
             <%= h(board.body || "") %>
@@ -20,7 +21,7 @@
         <% end %>
         <div class= "flex text-matcha font-bold" >
           <h1>＜<%= board.user.name %>＞</h1>
-          <%= board.updated_at.strftime("%m月%d日") %>
+          <%= board.updated_at.strftime('%y/%m/%d %H:%M') %>
         </div>
       </div>
     <% end %>

--- a/app/views/rooms/_form_board.html.erb
+++ b/app/views/rooms/_form_board.html.erb
@@ -1,5 +1,4 @@
 <div class="bg-white shadow z-50 p-4 fixed top-[220px] right-4 w-[150px] h-[260px] overflow-y-auto">
-  <!-- ホワイトボード入力エリア -->
   <div
     data-controller="board"
     data-board-room-id-value="<%= @room.id %>"
@@ -11,12 +10,11 @@
   <%= h(@whiteboard&.body || "") %>
   </div>
 
-  <!-- 投稿者と作成日 -->
   <% if @whiteboard.present? %>
     <div class="text-sm text-gray-600 border-t border-gray-200 pt-2">
       <p class="text-matcha">
         <span class="<%= @whiteboard.user == current_user ? 'text-gray-800 font-semibold' : '' %>">
-          <%= @whiteboard.user.name %>（<%= @whiteboard.updated_at.strftime("%m月%d日") %>）
+          <%= @whiteboard.user.name %>（<%= @whiteboard.updated_at.strftime('%Y/%m/%d %H:%M') %>）
         </span>
       </p>
     </div>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -11,11 +11,11 @@
         <%= f.label :visit_status, "ステータス" %>
         <%= f.select :visit_status,
         [["行ったことがある", "visited"], ["行きたい", "wanna_visit"]],
-        { prompt: "ステータスを選ぶ" },
+        { prompt: "⓵ステータスを選ぶ" },
         class: "bg-dark-gray/75 text-white py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha" %>
         <div class="mb-4">
         <%= f.label :name, "場所の名前 *場所名は自動入力されますが、適宜変更してください", class: "block text-dark-gray text-sm font-bold mb-2" %>
-        <%= f.text_field :name, id: "name", class: "w-full px-4 py-2 bg-light-gray/75 text-matcha rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
+        <%= f.text_field :name, id: "name", placeholder: "自動入力", class: "w-full px-4 py-2 bg-light-gray/75 text-matcha rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
         </div>
 
         <div class="mb-4">
@@ -23,7 +23,7 @@
             <%= f.label :address, "住所または場所名 *(例)東京都 スカイツリー", class: "block text-dark-gray text-sm font-bold mb-2" %>
             <button id="btn-search" class= "bg-blue/75 hover:bg-blue/30 text-dark-gray font-bold py-2 px-6 rounded-xl transition duration-200", data: { turbo: false } %>➡検索</button>
           </div>
-        <%= f.text_field :address, placeholder: "場所名を入力", id: "address", class: "w-full px-4 py-2 bg-light-gray/75 text-matcha rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
+        <%= f.text_field :address, placeholder: "⓶場所名を入力", id: "address", class: "w-full px-4 py-2 bg-light-gray/75 text-matcha rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
         </div>
         <div class="text-right">
         <%= link_to 'リセット', new_room_spot_path(@room), method: :get, class: "text-matcha" %>

--- a/app/views/spots/edit.html.erb
+++ b/app/views/spots/edit.html.erb
@@ -11,7 +11,8 @@
 
                 <p class="text-sm text-gray-700">
                 <strong>場所ID:</strong> <%= @spot.id %><br>
-                <strong>ステータス:</strong> <%= @spot.visit_status %><br>
+                <% status_labels = { "visited" => "行ったことがある", "wanna_visit" => "行きたい" } %>
+                <strong>ステータス:</strong> <%= status_labels[@spot.visit_status] || "不明" %><br>
                 <strong>登録日時:</strong> <%= l(@spot.created_at, format: :long) %><br>
                 <strong>ユーザー:</strong> <%= @spot.user.name %><br>
                 <strong>住所:</strong> <%= @spot.address %>
@@ -34,11 +35,11 @@
                     class: "bg-dark-gray/75 text-white py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha" %>
                     <!-- 場所名入力 -->
                     <div class="mb-4">
-                    <%= f.label :name, "場所の名前 *場所名は自動入力されますが、適宜変更してください", class: "block text-dark-gray text-sm font-bold mb-2" %>
+                    <%= f.label :name, "場所の名前 *場所名を適宜変更できます", class: "block text-dark-gray text-sm font-bold mb-2" %>
                     <%= f.text_field :name, id: "name", class: "w-full px-4 py-2 bg-gray/50 text-dark-gray rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
                     </div>
                     <div class="text-center">
-                        <%= f.submit "更新", class: "bg-gray/30 text-dark-gray py-2 px-6 rounded hover:bg-light-gray transition duration-200", data: { turbo: false } %>
+                        <%= f.submit "更新", class: "bg-blue/75 text-dark-gray py-2 px-6 rounded hover:bg-blue/20 transition duration-200", data: { turbo: false } %>
                     </div>
                     <%= link_to '<i class="fa-solid fa-trash text-lg text-blue"></i>'.html_safe, [@room, @spot], data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？"} %>
                   <% end %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -38,4 +38,4 @@
       <h2><i class="fa-solid fa-location-pin text-red-500"></i> まだ「行きたい場所」の登録はありません</h2>
   <% end %>
 </div>
-<%= link_to "#{@room.name}に戻る", room_path(@room) %>
+<%= link_to "#{@room.name}🏠に戻る", room_path(@room), class: "bg-brown/30 p-2 rounded shadow mb-2 mt-4 text-brown font-bold hover:bg-brown/70 transition" %>

--- a/app/views/state_calendars/_form.html.erb
+++ b/app/views/state_calendars/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="field">
-    <%= f.label :mental_state, "心の状態" %><br>
+    <%= f.label :mental_state, "心の状態", class: "text-dark-gray" %><br>
     <%= f.select :mental_state, 
         [
         ["🥳 : とても元気", "🥳"],
@@ -8,11 +8,11 @@
         ["😭 : 激しい落ち込み・涙が出る", "😭"],
         ["😣 : SOS / 相談に乗ってほしい", "😣"]
         ], 
-        prompt: "一番近い状態を選ぶ" %>
+        { prompt: "一番近い状態を選ぶ" }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha" %>
 </div>
 
 <div class="field">
-    <%= f.label :physical_state, "体の状態" %><br>
+    <%= f.label :physical_state, "体の状態", class: "text-dark-gray" %><br>
     <%= f.select :physical_state, 
         [
         ["💃 : エネルギッシュ", "💃"],
@@ -21,5 +21,5 @@
         ["🛌 : とても辛くて動けない", "🛌"],
         ["🤒 : SOS / 声をかけてほしい", "🤒"]
         ], 
-        prompt: "一番近い状態を選ぶ" %>
+        { prompt: "一番近い状態を選ぶ" }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha" %>
 </div>

--- a/app/views/state_calendars/edit.html.erb
+++ b/app/views/state_calendars/edit.html.erb
@@ -1,10 +1,10 @@
-<%= link_to "一覧へもどる", room_state_calendars_path(@room) %>
+<%= link_to "カレンダーへもどる", room_state_calendars_path(@room), class: "bg-light-gray/75 p-4 rounded shadow mb-4" %>
 
-<%= form_with model: [@room, @state_calendar], local: true do |f| %>
-  <%= f.date_field :date, value: @state_calendar.date || Date.current %>
+<%= form_with model: [@room, @state_calendar], local: true, class: "bg-light-gray/75 p-4 rounded shadow mb-4" do |f| %>
+  <%= f.date_field :date, value: @state_calendar.date || Date.current, class: "text-dark-gray bg-matcha/30" %>
     <%= render 'form', f: f %>
-        <div class="flex">
-            <%= f.submit "更新", style: "padding: 10px 20px; background-color: #ccc;" %>
+        <div class="text-center">
+            <%= f.submit "更新", class:"bg-blue/75 text-dark-gray py-2 px-6 rounded hover:bg-blue/30 transition duration-200 mt-2", data: { turbo: false } %>
             <%= link_to '<i class="fa-solid fa-trash text-lg text-blue"></i>'.html_safe, room_state_calendar_path(@room, @state_calendar), data: { turbo_method: :delete, turbo_confirm: "本当に記録を消しますか？" } %>
         </div>
 <% end %>

--- a/app/views/state_calendars/index.html.erb
+++ b/app/views/state_calendars/index.html.erb
@@ -1,3 +1,6 @@
+<h1 class="text-dark-gray font-bold">"<%= @room.name %>" のカレンダー</h1>
+<%= link_to "+ 本日 #{ Time.current.strftime("%Y年%m月%d日") }の心身登録", new_room_state_calendar_path(@room), class: "bg-gray p-4 rounded shadow mb-4 mt-2 hover:bg-blue/75 transition text-beige" %>
+<h1 class="text-dark-gray">※<%= current_user.name %>さんのカレンダーの日付をクリック➡ 心身状況の登録・更新・削除ができます。
 <% @calendar_users.each do |user| %>
   <% user_is_current = user == current_user %>
   <% user_calendars = @calendars_by_user[user.id] || [] %>
@@ -33,10 +36,6 @@
     <% end %>
   </div>
 <% end %>
-
-
-
-<%= link_to "+ 心身の登録", new_room_state_calendar_path(@room) %>
-<div class="text-brown flex space-x-2">
-    <%= link_to "部屋に戻る", room_path(@room),data: { turbo: false }, method: :delete %>
+<div class="flex justify-center">
+  <%= link_to "#{@room.name}🏠に戻る", room_path(@room), class: "bg-brown/30 p-2 rounded shadow mb-2 mt-4 text-brown font-bold hover:bg-brown/70 transition" %>
 </div>

--- a/app/views/state_calendars/new.html.erb
+++ b/app/views/state_calendars/new.html.erb
@@ -1,10 +1,10 @@
-<%= link_to "一覧へ戻る", room_state_calendars_path(@room), class: "bg-light-gray/75 p-4 rounded shadow mb-4" %>
+<%= link_to "カレンダーへ戻る", room_state_calendars_path(@room), class: "bg-light-gray/75 p-4 rounded shadow mb-4" %>
 
-<%= form_with model: [@room, @state_calendar], local: true do |f| %>
-  <%= f.date_field :date, value: @state_calendar.date || Date.current %>
+<%= form_with model: [@room, @state_calendar], local: true, class: "max-w-md mx-auto p-6 bg-light-gray/50 rounded-2xl shadow-lg mt-2" do |f| %>
+  <%= f.date_field :date, value: @state_calendar.date || Date.current, class: "text-dark-gray bg-matcha/30" %>
     <%= render 'form', f: f %>
-  <div class="flex">
-    <%= f.submit "保存", class: "bg-light-blue/75 text-dark-gray py-2 px-6 rounded hover:bg-light-blue transition duration-200, data: { turbo: false }" %>
+  <div class="text-center">
+    <%= f.submit "保存", class: "bg-blue/75 text-dark-gray py-2 px-6 rounded hover:bg-blue/30 transition duration-200 mt-2", data: { turbo: false } %>
   </div>
 <% end %>
 


### PR DESCRIPTION
# 全体的なCSS調整を行いました
- [x] greeting登録画面CSS調整
- [x] greeting一覧画面CSS調整
- [x] exchange_diaries一覧画面CSS調整
- [x] invitation_tokens一覧画面CSS調整
- [x] whiteboardの更新日時(何時何分)追加
- [x] spots一覧画面CSS調整
- [x] state_calendars一覧/編集/新規作成画面CSS調整
# 住んでいる地域登録のフラッシュメッセージが発火しない問題を解決
- [x] app/views/layouts/application.html.erbのフラッシュメッセージの記述を<head>から<body>の<%= yield %>前に移動

# 作業ブランチ
- feature42/adjust_css
