### PR TITLE
feature47/fix_show_room

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  # allow_browser versions: :modern
 end

--- a/app/views/rooms/_board.html.erb
+++ b/app/views/rooms/_board.html.erb
@@ -20,8 +20,8 @@
           <%= board.body %>
         <% end %>
         <div class= "flex text-matcha font-bold" >
-          <h1>＜<%= board.user.name %>＞</h1>
-          <%= board.updated_at.strftime('%y/%m/%d %H:%M') %>
+          <h1><%= board.user.name %></h1>
+          (<%= board.updated_at.strftime('%y/%m/%d %H:%M') %>)
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
# モバイル版で開くと、クラッシュしてしまう問題対処
-  app/controllers/application_controller.rbにrails newで自動記述される ``allow_browser versions: :modern`` を
一時コメントアウト。

# 作業ブランチ
- feature47/fix_show_room