### PR TITLE
mobile_or_pc_room

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def mobile_device?
+    request.user_agent =~ /Mobile|webOS/
+  end
 end

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -35,3 +35,9 @@
     class: "btn-message inline-block px-4 py-2 bg-brown/75 text-dark-gray rounded hover:bg-brown/30 transition",
     style: "position:fixed;top:600px;right:10px;z-index:9999;"
 %>
+
+<% if mobile_device? %>
+  <%= image_tag '/room_top2.png' %>
+<% else %>
+  <%= render 'home' %>
+<% end %>


### PR DESCRIPTION
# モバイル版/PC版でroomのshowページの背景をswitchする実装
- (背景) glbファイルが軽量化後も重く、モバイル版でクラッシュする
(試したこと)
- モバイル版は、背景を画像に変更
- PC版は、背景をそのままglbファイルを表示

# 作業ブランチ
- feature50/mobile_or_pc_room