### PR TITLE
Feature55/fix calendar

### DIFF
--- a/app/controllers/state_calendars_controller.rb
+++ b/app/controllers/state_calendars_controller.rb
@@ -54,7 +54,7 @@ class StateCalendarsController < ApplicationController
     else
       @state_calendars = @room.state_calendars.includes(:user).order(created_at: :desc)
       flash.now[:alert] = "心身コンディションの更新に失敗しました"
-      render :edit, status: :unprocessable_entity
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/state_calendars_controller.rb
+++ b/app/controllers/state_calendars_controller.rb
@@ -54,7 +54,7 @@ class StateCalendarsController < ApplicationController
     else
       @state_calendars = @room.state_calendars.includes(:user).order(created_at: :desc)
       flash.now[:alert] = "心身コンディションの更新に失敗しました"
-      render :new, status: :unprocessable_entity
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/state_calendars_controller.rb
+++ b/app/controllers/state_calendars_controller.rb
@@ -11,20 +11,25 @@ class StateCalendarsController < ApplicationController
 
   def new
   @room = Room.find(params[:room_id])
-  # date指定で既存の記録があれば取得する例
   @state_calendar = current_user.state_calendars.find_by(room: @room, date: params[:date]) || current_user.state_calendars.new(room: @room, date: params[:date] || Date.current)
   end
 
   def create
-    @room = Room.find(params[:room_id])
-    @state_calendar = current_user.state_calendars.new(state_calendar_params)
-    @state_calendar.room = @room
-    @state_calendar.user = current_user
+  @room = Room.find(params[:room_id])
+  existing_calendar = current_user.state_calendars.find_by(date: state_calendar_params[:date], room_id: @room.id)
 
-    if @state_calendar.save
-      redirect_to room_state_calendars_path(@room), notice: "心身コンディションを保存しました"
+    if existing_calendar
+      flash[:alert] = "この日付の記録はすでに存在します。カレンダーから選択、更新してください。"
+      redirect_to room_state_calendars_path(@room)
     else
-      render :new, status: :unprocessable_entity
+      @state_calendar = current_user.state_calendars.new(state_calendar_params)
+      @state_calendar.room = @room
+
+      if @state_calendar.save
+        redirect_to room_state_calendars_path(@room), notice: "心身コンディションを保存しました"
+      else
+        render :new, status: :unprocessable_entity
+      end
     end
   end
 

--- a/app/models/state_calendar.rb
+++ b/app/models/state_calendar.rb
@@ -4,6 +4,7 @@ class StateCalendar < ApplicationRecord
 
   validates :mental_state, presence: true
   validates :physical_state, presence: true
+  validates :date, uniqueness: { scope: :user_id }
 
   def calendar_date
     date.presence || created_at

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,23 +8,33 @@ ja:
         name: 場所名
         visit_status: ステータス
       state_calendar:
+        date: この日付の記録
         mental_state: 心の状態
         physical_state: 体の状態
       greeting:
         greeting_type: ステータス
         message: メッセージ
+
+    errors:
+      models:
+        state_calendar:
+          attributes:
+            date:
+              taken: "はすでに存在します。カレンダーから該当日付を選び、更新できます。"
+            mental_state:
+              blank: "を選択してください"
+            physical_state:
+              blank: "を選択してください"
+
   errors:
     messages:
       blank: "を入力してください"
     attributes:
       visit_status:
         blank: "を選択してください"
-      mental_state:
-        blank: "を選択してください"
-      physical_state:
-        blank: "を選択してください"
       greeting_type:
         blank: "を選択してください"
+
   views:
     pagination:
       first: "&laquo; 最初"


### PR DESCRIPTION
# カレンダーの更新時エラーの対処
(状況)
- すでに登録のある日付を押すと、編集画面に遷移します。
- 編集画面で日付、心の状態、身体の状態の変更が可能です。
(問題)
- 編集画面で日付を変更した際、その日付にすでに登録があった場合にエラーが起きます。
(対処)
- 編集画面で日付を変更しようとした際、その日付にすでに登録があった場合にコントローラで画面遷移＆バリデーションエラーを起こします。
# 作業ブランチ
- feature55/fix_calendar