### PR TITLE
calendar_uniqueness_add_roomid

### DIFF
--- a/app/models/state_calendar.rb
+++ b/app/models/state_calendar.rb
@@ -4,7 +4,7 @@ class StateCalendar < ApplicationRecord
 
   validates :mental_state, presence: true
   validates :physical_state, presence: true
-  validates :date, uniqueness: { scope: :user_id }
+  validates :date, uniqueness: { scope: [ :user_id, :room_id ] }
 
   def calendar_date
     date.presence || created_at

--- a/app/views/state_calendars/index.html.erb
+++ b/app/views/state_calendars/index.html.erb
@@ -1,8 +1,9 @@
-<h1 class="text-dark-gray font-bold">"<%= @room.name %>" のカレンダー</h1>
+<h1 class="text-matcha-green text-xl font-bold">"<%= @room.name %>" のカレンダー</h1>
 <% unless @today_state.present? %>
   <%= link_to "+ 本日 #{ Time.current.strftime("%Y年%m月%d日") }の心身登録", new_room_state_calendar_path(@room), class: "bg-gray p-4 rounded shadow mb-4 mt-2 hover:bg-blue/75 transition text-beige" %>
 <% end %>
-<h1 class="text-dark-gray">※<%= current_user.name %>さんのカレンダーの日付をクリック➡ 心身状況の登録・更新・削除ができます。
+<h1 class="text-dark-gray">※<%= current_user.name %>さんのカレンダーの日付をクリック➡ 心身状況の登録・更新・削除ができます。</h1>
+<h1 class="text-dark-gray">※カレンダーは部屋ごとに分かれており、同ユーザーでも記録は別々です。</h1>
 <% @calendar_users.each do |user| %>
   <% user_is_current = user == current_user %>
   <% user_calendars = @calendars_by_user[user.id] || [] %>

--- a/db/migrate/20250624064408_change_unique_index_on_state_calendars.rb
+++ b/db/migrate/20250624064408_change_unique_index_on_state_calendars.rb
@@ -1,0 +1,6 @@
+class ChangeUniqueIndexOnStateCalendars < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :state_calendars, name: "index_state_calendars_on_user_id_and_date"
+    add_index :state_calendars, [ :user_id, :room_id, :date ], unique: true, name: "index_state_calendars_on_user_room_date"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_30_093903) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_24_064408) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -98,7 +98,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_30_093903) do
     t.datetime "updated_at", null: false
     t.date "date"
     t.index ["room_id"], name: "index_state_calendars_on_room_id"
-    t.index ["user_id", "date"], name: "index_state_calendars_on_user_id_and_date", unique: true
+    t.index ["user_id", "room_id", "date"], name: "index_state_calendars_on_user_room_date", unique: true
     t.index ["user_id"], name: "index_state_calendars_on_user_id"
   end
 


### PR DESCRIPTION
# 部屋ごとに個別の心身状況が登録できるよう修正
- (以前まで)同じuser_idと同じdateの心身状況データを複数持つことができない
- (修正)同じuser_id, 同じdate, **同じroom_id** の心身状況データを複数持つことができない
___
 できるようになったこと
  -  (前提)ビューファイルではカレンダーおよび、心身状況のデータ表示は部屋ごとに管理していました。しかし、DBレベルでは同user_idと同dateを持つ心身状況データを１つしか持てない仕様になっており、一方の部屋のカレンダーは新規登録画面に飛べるのに「データがすでにあります」と弾かれる事象が起きていました。
  - (修正後)同じユーザー、同じ日付であっても、部屋ごとに心身状況を登録できるようになりました。
  ```
  create_table "state_calendars", force: :cascade do |t|
    t.bigint "user_id", null: false
    t.bigint "room_id", null: false
    t.string "mental_state"
    t.string "physical_state"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
    t.date "date"
    t.index ["room_id"], name: "index_state_calendars_on_room_id"
    **t.index ["user_id", "room_id", "date"], name: "index_state_calendars_on_user_room_date", unique: true**
    t.index ["user_id"], name: "index_state_calendars_on_user_id"
  end
  ```

# 作業ブランチ
- feature61/calendar_uniqueness