### PR TITLE
fix/comment_error

### DIFF
--- a/app/views/posts/_share.html.erb
+++ b/app/views/posts/_share.html.erb
@@ -1,4 +1,0 @@
-<div class ="text-center title ">
-    <%= link_to 'share', "https://x.com/share?url=https://online-room.onrender.com/&text=【🏠#{@post.post_type}】～#{@post.content}～を投稿しました！", 
-    title: 'X',class:'fa-brands fa-x-twitter', target: '_blank', rel: "noopener" %>
-</div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -53,7 +53,10 @@
       </div>
       <%= link_to '<i class="fa-solid fa-trash text-lg text-blue"></i>'.html_safe, @post, data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？"} %>
     <% end %>
-    <%= render 'share' %>
+    <div class ="text-center title ">
+        <%= link_to 'share', "https://x.com/share?url=https://online-room.onrender.com/&text=【🏠#{@post.post_type}】～#{@post.content}～を投稿しました！", 
+        title: 'X',class:'fa-brands fa-x-twitter', target: '_blank', rel: "noopener" %>
+    </div>
   </div>
 </div>
 <div class="flex justify-center">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -26,7 +26,10 @@
     <p class="text-gray-700 mt-3">
       <strong>登録日時:</strong> <%= l(@post.created_at, format: :long) %>
     </p>
-    <%= render 'share' %>
+    <div class ="text-center title ">
+        <%= link_to 'share', "https://x.com/share?url=https://online-room.onrender.com/&text=【🏠#{@post.post_type}】～#{@post.content}～を投稿しました！", 
+        title: 'X',class:'fa-brands fa-x-twitter', target: '_blank', rel: "noopener" %>
+    </div>
   </div>
 </div>
 <div class="w-full max-w-3xl bg-light-gray/40 p-6 rounded-lg shadow-lg mb-6">


### PR DESCRIPTION
# コメント入力のエラー時に、遷移が失敗していた問題対処
- posts/showを遷移先にしていたが、その中にshareパーシャルファイルがあり、読み込みに失敗していました。
- パーシャルの中身が少なかったことから、パーシャルを削除してposts/showに直接記述しました。
# 作業ブランチ
- feature77/comment_error_message