### PR TITLE
add/greeting_color_pc

### DIFF
--- a/app/views/rooms/_greeting.html.erb
+++ b/app/views/rooms/_greeting.html.erb
@@ -1,11 +1,11 @@
 <% if flash[:just_signed_in] %>
   <div id="login-greeting">
-  <div class="fixed top-[580px] md:top-[600px] left-0 z-50 justify-end text-beige">
+  <div class="fixed top-[580px] md:top-[600px] left-0 z-50 justify-end text-beige md:text-black">
     <p><%= @welcome_display[:user].name %></p>
     <p class="bg-blue/50 p-4 rounded-lg shadow-md"><%= @welcome_display[:message] %></p>
   </div>
 
-  <div class="fixed top-[500px] md:top-[520px] left-0 z-50 justify-end text-beige">
+  <div class="fixed top-[500px] md:top-[520px] left-0 z-50 justify-end text-beige md:text-black">
     <p><%= @return_display[:user].name %></p>
     <p class="bg-matcha/50 p-4 rounded-lg shadow-md"><%= @return_display[:message] %></p>
   </div>


### PR DESCRIPTION
# PC版の背景と「ただいま」「おかえり」メッセージの色が被って見えない問題の対処
- モバイル版では、ベージュ色のテキストメッセージ
- PC版では、黒色のテキストメッセージ

# 作業ブランチ
- feature79/messages_color