### PR TITLE
fix/naming_buttons

### DIFF
--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -6,25 +6,25 @@
 </div>
 <%= render 'weather' %>
 <%= render 'board' %>
-<%= link_to '心身カレンダー', room_state_calendars_path(@room),
+<%= link_to '心身コンディション', room_state_calendars_path(@room),
     class: "btn-calendar fixed top-[400px] md:top-[250px] right-0 z-50 inline-block px-2 py-2 bg-blue/75 text-beige text-md md:text-xl rounded hover:bg-matcha/30 transition",
     data: { turbo: false }
 %>
 <!--%= render 'calendar' %>-->
 <% if @room.user_id == current_user.id %>
-    <%= link_to "同居人を招待　", room_invitation_tokens_path(@room),
-        class: "btn-exchange fixed top-[250px] md:top-[100px] right-0 z-50 inline-block px-2 py-2 bg-matcha-green text-beige text-md md:text-xl rounded hover:bg-matcha/30 transition",
+    <%= link_to "同居人を招待　　　", room_invitation_tokens_path(@room),
+        class: "btn-exchange fixed top-[250px] md:top-[100px] right-0 z-50 inline-block px-2 py-2 bg-matcha-green/75 text-beige text-md md:text-xl rounded hover:bg-matcha/30 transition",
         data: { turbo: false }
     %>
 <% end %>
 
 <%= render 'greeting' %>
-<%= link_to "交換日記　　　", room_exchange_diaries_path(@room),
+<%= link_to "交換日記　　　　　", room_exchange_diaries_path(@room),
     class: "btn-exchange fixed top-[300px] md:top-[150px] right-0 z-50 inline-block px-2 py-2 bg-matcha/30 text-beige text-md md:text-xl rounded hover:bg-blue/30 transition",
     id: "open-book",
     data: { room_path: room_exchange_diaries_path(@room), turbo: false }
 %>
-<%= link_to "秘密基地　　　", room_spots_path(@room),
+<%= link_to "想い出スポット　　", room_spots_path(@room),
     class: "btn-spot fixed top-[350px] md:top-[200px] right-0 z-50 inline-block px-2 py-2 bg-matcha/30 text-beige text-md md:text-xl rounded hover:bg-blue/30 transition",
     id: "open-door",
     data: { room_path: room_spots_path(@room), turbo: false }


### PR DESCRIPTION
# ボタンのネーミングを、機能がわかるように編集
- 「秘密基地」→「想い出スポット」
- 「心身カレンダー」→「心身コンディション」

# 作業ブランチ
- feature85/naming_buttons