### PR TITLE
add/login_status

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   # allow_browser versions: :modern
   before_action :set_locale
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :update_last_seen, if: :user_signed_in?
 
   def set_locale
     I18n.locale = params[:locale] || I18n.default_locale
@@ -17,6 +18,10 @@ class ApplicationController < ActionController::Base
   end
 
   protected
+
+  def update_last_seen
+    current_user.update_column(:last_seen_at, Time.current)
+  end
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,9 @@
 module UsersHelper
+  def last_seen_text(user)
+    return t("views.user.status.online") if user.online?
+    return t("views.user.status.offline") unless user.last_seen_at
+
+    time = time_ago_in_words(user.last_seen_at)
+    t("views.user.status.went_out_ago", time: time)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,15 @@ class User < ApplicationRecord
     id == object&.user_id
   end
 
+  def online?
+    return false unless last_seen_at
+    last_seen_at > 5.minutes.ago
+  end
+
+  def offline?
+    !online?
+  end
+
   # 同じ部屋に所属するユーザー全員
   def grouped_shared_users
     Room.where(id: owned_rooms.pluck(:id) + rooms.pluck(:id))

--- a/app/views/rooms/_status.html.erb
+++ b/app/views/rooms/_status.html.erb
@@ -1,0 +1,4 @@
+<div class="flex items-center">
+  <span class="inline-block w-2 h-2 rounded-full mr-1 <%= user.online? ? 'bg-green-500' : 'bg-gray' %>"></span>
+  <span class="text-xs text-gray-600"><%= last_seen_text(user) %></span>
+</div>

--- a/app/views/rooms/_weather.html.erb
+++ b/app/views/rooms/_weather.html.erb
@@ -31,6 +31,7 @@
             <p><i class="fa-solid fa-clock text-matcha-green/75"></i> <%= weather_record.updated_at.strftime('%m/%d %H:%M') %></p>
           <% end %>
           <%= button_to t('buttons.update'), weather_record_path(weather_record, area_id: user.area.id, room_id: @room.id), method: :patch, data: { turbo: false }, class: "text-blue underline font-bold" %>
+          <%= render "status", user: user %>
         <% end %>
       <% end %>
     </div>
@@ -76,6 +77,7 @@
           method: :patch,
           data: { turbo: false },
           class: "text-blue underline font-bold" %>
+          <%= render "status", user: current_user %>
       <% end %>
     <% end %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,6 +234,10 @@ en:
     user:
       profile: "%{name}'s profile"
       edit: "Edit Name/Email/Password"
+      status:
+        online: "At Home"
+        offline: "Away"
+        went_out_ago: "Went out %{time} ago"
 
     area:
       rule: "Enter your area of residence *City or Ward (in English)"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -234,6 +234,10 @@ ja:
     user:
       profile: "%{name}さんのプロフィール"
       edit: "名前/メールアドレス/パスワード編集"
+      status:
+        online: "帰宅中"
+        offline: "外出中"
+        went_out_ago: "%{time}前に外出"
 
     area:
         rule: "あなたのお住まいの地域 *市or区 (ローマ字＆小文字入力)"

--- a/db/migrate/20250717050400_add_last_seen_at_to_users.rb
+++ b/db/migrate/20250717050400_add_last_seen_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastSeenAtToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :last_seen_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_14_130504) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_17_050400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -138,6 +138,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_14_130504) do
     t.datetime "updated_at", null: false
     t.string "provider"
     t.string "uid"
+    t.datetime "last_seen_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true


### PR DESCRIPTION
- [x] 同じ部屋にいる相手がログイン中か・ログアウト中か判定
- [x] 部屋のルームメイトがログイン中・ログアウト中の表示
___
発想の転換！！
➡最後に見た時間＝外出時間とする
- [x] userテーブルにlast_seen_dateカラムを追加
- [x] userモデルにoffline/onlineの定義を追加
  ```
  # ５分以内に見ていたらオンラインと判定
  def online?
    return false unless last_seen_at
    last_seen_at > 5.minutes.ago
  end

  def offline?
    !online?
  end
  ```
- [x] userヘルパーに「何分前に見た」＝「何分前に外出した」かを表示するロジック記載
   ```
  module UsersHelper
    def last_seen_text(user)
      return t("views.user.status.online") if user.online?
      return t("views.user.status.offline") unless user.last_seen_at
  
      time = time_ago_in_words(user.last_seen_at)
      t("views.user.status.went_out_ago", time: time)
    end
  end

  # time_ago_in_wordsは、-分前/-時間前/-日前を自動で変換してくれるrailsの機能（日英対応）
  ```
# 備考
- deviseの機能として、if user signed in?が使えるのは、current_userだけ
- 他ユーザーのログイン状態を確認するには、別のロジックが必要
- 「ログインしてるか？」だと、ログアウトのし忘れが発生する➡「最後に見た時間」の方が厳密かつ実装がしやすい
-  last_seen_atを活用
# 参考
https://stackoverflow.com/questions/20821341/rails-how-to-show-users-last-seen-at-time