### PR TITLE
add/tips_answer_display_name

### DIFF
--- a/app/views/answers/_answer.html.erb
+++ b/app/views/answers/_answer.html.erb
@@ -1,5 +1,5 @@
 <div class="bg-beige/40 p-6 rounded-lg shadow-lg mb-6">
-    <h3 class="text-sm font-semibold text-matcha"><i class="fa-regular fa-user"></i><%= answer.user.name %></h3>
+    <h3 class="text-sm font-semibold text-matcha"><i class="fa-regular fa-user"></i><%= answer.user == answer.post.user ? "投稿主" : answer.user.name %></h3>
     <p class="text-gray-700"><%= simple_format(answer.body) %></p>
 <% if current_user&.own?(answer) %>
     <ul class="flex justify-end space-x-2">


### PR DESCRIPTION
- （前提)tipsページで、投稿者は匿名/ユーザー名/表示名を選択できます。コメント作成者は、責任を持った発言＆モラルのない発言を防ぐためにユーザー名が表示されるようになっています。

- （対策したいこと）投稿者が、もらったコメントに返事がしたいときに名前がばれてしまうため、投稿主がコメントをするときは、投稿したときの名前の形態がそのまま反映されるようにしたい

~~answerコントローラを編集~~
~~app/views/posts/edit.html.erbファイルを編集~~

- [x] app/views/answers/_answer.html.erb
```
<%= answer.user.name %>
# 上記を以下に変更
<%= answer.user == answer.post.user ? "投稿主" : answer.user.name %>
```