### PR TITLE
Feature97/calendars

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -1,0 +1,43 @@
+class CalendarsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_room
+
+  def index
+  end
+
+  def new
+    @room = Room.find(params[:room_id])
+    @calendar = current_user.calendars.find_by(room: @room, start_time: params[:start_time]) || current_user.calendars.new(room: @room, start_time: params[:start_time] || Date.current)
+  end
+
+  def create
+    @calendar = current_user.calendars.new(calendar_params)
+    @calendar.room = @room
+
+    if @calendar.save
+      redirect_to room_calendars_path(@room), notice: "予定を作成しました"
+    else
+      flash.now[:alert] = t("flash.state_calendar.failed_save")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def destroy
+  end
+
+  private
+
+  def set_room
+    @room = Room.find_by(id: params[:room_id])
+    unless @room && (@room.user_id == current_user.id || RoommateList.exists?(user_id: current_user.id, room_id: @room.id))
+      redirect_to root_path, alert: t("flash.room.failed_find")
+    end
+  end
+
+  def calendar_params
+    params.require(:calendar).permit(:name, :description, :schedule_type, :start_time, :end_time, :visibility, :category, :source, :user_id, :room_id)
+  end
+end

--- a/app/helpers/calendars_helper.rb
+++ b/app/helpers/calendars_helper.rb
@@ -1,0 +1,2 @@
+module CalendarsHelper
+end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -1,0 +1,2 @@
+class Calendar < ApplicationRecord
+end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -1,2 +1,50 @@
 class Calendar < ApplicationRecord
+  before_validation :adjust_all_day_times
+
+  belongs_to :user
+  belongs_to :room
+
+  validates :start_time, presence: true
+  validates :end_time, presence: true
+
+  enum schedule_type: { all_day: 0, timed: 1 }
+  enum source: { manual: 0, google: 1 }
+  enum visibility: { personal: 0, share_only: 1, together: 2 }
+  enum category: { relax: 0, work_study: 1, event: 2 }
+
+  def display_start_time
+    if schedule_type == "all_day"
+      start_time.strftime("%Y-%m-%d")
+    else
+      start_time.strftime("%Y-%m-%d %H:%M")
+    end
+  end
+
+  def display_end_time
+    return nil if schedule_type == "all_day" && start_time.to_date == end_time.to_date
+
+    if schedule_type == "all_day"
+      end_time.strftime("%Y-%m-%d")
+    else
+      end_time.strftime("%Y-%m-%d %H:%M")
+    end
+  end
+
+  def all_day?
+    schedule_type == "all_day"
+  end
+
+  private
+
+  def adjust_all_day_times
+    return unless all_day?
+
+    if start_time.present?
+      self.start_time = start_time.beginning_of_day
+    end
+
+    if end_time.present?
+      self.end_time = end_time.end_of_day
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :answers, dependent: :destroy
   has_many :reads, dependent: :destroy
+  has_many :calendars, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -1,0 +1,4 @@
+<h1>どうも</h1>
+
+<%= link_to t("views.room.back_to_room", room_name: @room.name), room_path(@room), class: "bg-brown/30 p-2 rounded shadow mb-2 mt-4 text-brown font-bold hover:bg-brown/70 transition", data: { turbo: false } %>
+<%= link_to t("buttons.new"), new_room_calendar_path(), class: "bg-blue/75 p-4 rounded shadow mb-4 mt-2 hover:bg-blue-30 transition text-dark-gray", data: { turbo: false } %>

--- a/app/views/calendars/new.html.erb
+++ b/app/views/calendars/new.html.erb
@@ -1,0 +1,105 @@
+<%= form_with model: [@room, @calendar], local: true, class: "max-w-md mx-auto p-6 bg-light-gray/50 rounded-2xl shadow-lg mt-2" do |f| %>
+  <% if @calendar.errors.any? %>
+    <div class="error-messages bg-red-100 text-red-700 p-4 mb-4 rounded">
+      <h2>入力エラーがあります：</h2>
+      <ul>
+        <% @calendar.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <div class="schedule-type-selection">
+    <%= f.radio_button :schedule_type, "timed", id: "schedule_type_timed", checked: true %>
+    <%= f.label :schedule_type_timed, "時間指定" %>
+
+    <%= f.radio_button :schedule_type, "all_day", id: "schedule_type_all_day" %>
+    <%= f.label :schedule_type_all_day, "終日" %>
+  </div>
+
+  <!-- 終日 -->
+  <div id="all-day-fields" style="display: none;">
+    <div class="form-group">
+      <%= f.label :start_time, '開始日' %>
+      <%= f.date_field :start_time, class: 'form-control', value: Time.current.strftime("%Y-%m-%d") %>
+    </div>
+    <div class="form-group">
+      <%= f.label :end_time, '終了日' %>
+      <%= f.date_field :end_time, class: 'form-control', value: Time.current.strftime("%Y-%m-%d") %>
+    </div>
+  </div>
+
+  <!-- 時間指定　-->
+  <div id="timed-fields">
+    <div class="form-group">
+      <%= f.label :start_time, '開始日時' %>
+      <%= f.datetime_local_field :start_time, class: 'form-control', value: Time.current.strftime("%Y-%m-%dT%H:%M") %>
+    </div>
+    <div class="form-group">
+      <%= f.label :end_time, '終了日時' %>
+      <%= f.datetime_local_field :end_time, class: 'form-control', value: (Time.current + 30.minutes).strftime("%Y-%m-%dT%H:%M") %>
+    </div>
+  </div>
+
+  <div>
+    <%= f.label :name, "件名" %>
+    <%= f.text_field :name, placeholder: t("views.greeting.enter"), class: "w-full px-4 py-2 bg-light-gray/75 text-matcha rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
+
+    <%= f.label :source, "calendar_type", class: "text-dark-gray" %>
+    <%= f.select :source,
+      [["グーグル", "google"], ["マニュアル", "manual"]],
+      { prompt: "選んでください" }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha"
+    %>
+
+    <%= f.label :description, "note", class: "text-dark-gray" %>
+    <%= f.text_field :description, placeholder: "note", class: "w-full px-4 py-2 bg-light-gray/75 text-matcha rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
+
+    <%= f.label :category, "category", class: "text-dark-gray" %>
+    <%= f.select :category,
+      [["用事・その他", "event"], ["仕事・勉強", "work_study"],["リラックス", "relax"]],
+      { prompt: "選んでください" }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha"
+    %>
+
+    <%= f.label :visibility, "閲覧権限", class: "text-dark-gray" %>
+    <%= f.select :visibility,
+      [["自分だけ", "personal"], ["共有のみ", "share_only"],["一緒の予定", "together"]],
+      { prompt: "選んでください" }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha"
+    %>
+  </div>
+  <div class="text-center">
+    <%= f.submit t("buttons.save"), class: "bg-blue/75 text-dark-gray py-2 px-6 rounded hover:bg-blue/30 transition duration-200 mt-2", data: { turbo: false } %>
+  </div>
+<% end %>
+
+<%= link_to t("buttons.back"), room_calendars_path(@room), class: "bg-light-gray/75 py-2 px-6 rounded shadow mb-4 hover:bg-light-gray/50 transition text-dark-gray" %>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const timedRadio = document.querySelector('#schedule_type_timed');
+    const allDayRadio = document.querySelector('#schedule_type_all_day');
+
+    const timedFields = document.getElementById('timed-fields');
+    const allDayFields = document.getElementById('all-day-fields');
+
+    function toggleFields() {
+      const isAllDay = allDayRadio.checked;
+
+      timedFields.style.display = isAllDay ? 'none' : 'block';
+      allDayFields.style.display = isAllDay ? 'block' : 'none';
+
+      // 各 input を有効・無効化
+      allDayFields.querySelectorAll('input').forEach(input => {
+        input.disabled = !isAllDay;
+      });
+      timedFields.querySelectorAll('input').forEach(input => {
+        input.disabled = isAllDay;
+      });
+    }
+
+    timedRadio.addEventListener('change', toggleFields);
+    allDayRadio.addEventListener('change', toggleFields);
+
+    toggleFields(); // 初期化
+  });
+</script>
+

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -7,7 +7,7 @@
 <%= render 'weather' %>
 <%= render 'board' %>
 <%= link_to t('views.room_show.state'), room_state_calendars_path(@room),
-    class: "btn-calendar fixed top-[400px] md:top-[250px] right-0 z-50 inline-block px-2 py-2 bg-blue/75 text-beige text-md md:text-xl rounded hover:bg-matcha/30 transition",
+    class: "btn-state-calendar fixed top-[400px] md:top-[250px] right-0 z-50 inline-block px-2 py-2 bg-blue/75 text-beige text-md md:text-xl rounded hover:bg-matcha/30 transition",
     data: { turbo: false }
 %>
 <!--%= render 'calendar' %>-->
@@ -31,6 +31,11 @@
 %>
 <%= link_to t('views.room_show.message'), room_greetings_path(@room),
     class: "btn-message fixed top-[480px] md:top-[600px] right-0 z-50 inline-block px-2 py-2 bg-matcha-green/65 text-beige text-md md:text-xl rounded hover:bg-matcha/30 transition",
+    data: { turbo: false }
+%>
+
+<%= link_to t('views.room_show.calendar'), room_calendars_path(@room),
+    class: "btn-calendar fixed top-[450px] md:top-[300px] right-0 z-50 inline-block px-2 py-2 bg-blue/75 text-beige text-md md:text-xl rounded hover:bg-matcha/30 transition",
     data: { turbo: false }
 %>
 

--- a/app/views/simple_calendar/_calendar.html.erb
+++ b/app/views/simple_calendar/_calendar.html.erb
@@ -3,9 +3,9 @@
     <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
 
     <nav>
-      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
-      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
-      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+      <%= link_to t('views.simple_calendar.previous'), calendar.url_for_previous_view %>
+      <%= link_to t('views.simple_calendar.today'), calendar.url_for_today_view %>
+      <%= link_to t('views.simple_calendar.next'), calendar.url_for_next_view %>
     </nav>
   </div>
 

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -5,9 +5,9 @@
     </time>
 
     <nav class="space-x-2">
-      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view, class: "px-3 py-1 bg-light-gray/50 hover:bg-light-gray rounded-lg text-sm text-dark-gray" %>
-      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view, class: "px-3 py-1 bg-green-100 hover:bg-green-200 rounded-lg text-sm text-green-700" %>
-      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view, class: "px-3 py-1 bg-light-gray/50 hover:bg-light-gray rounded-lg text-sm text-dark-gray" %>
+      <%= link_to t('views.simple_calendar.previous'), calendar.url_for_previous_view, class: "px-3 py-1 bg-light-gray/50 hover:bg-light-gray rounded-lg text-sm text-dark-gray" %>
+      <%= link_to t('views.simple_calendar.today'), calendar.url_for_today_view, class: "px-3 py-1 bg-green-100 hover:bg-green-200 rounded-lg text-sm text-green-700" %>
+      <%= link_to t('views.simple_calendar.next'), calendar.url_for_next_view, class: "px-3 py-1 bg-light-gray/50 hover:bg-light-gray rounded-lg text-sm text-dark-gray" %>
     </nav>
   </div>
 

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -17,9 +17,9 @@
     </span>
 
     <nav class="space-x-2">
-      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view, class: "px-3 py-1 bg-light-gray/50 hover:bg-light-gray rounded-lg text-sm text-dark-gray" %>
-      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view, class: "px-3 py-1 bg-green-100 hover:bg-green-200 rounded-lg text-sm text-green-700" %>
-      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view, class: "px-3 py-1 bg-light-gray/50 hover:bg-light-gray rounded-lg text-sm text-dark-gray" %>
+      <%= link_to t('views.simple_calendar.previous'), calendar.url_for_previous_view, class: "px-3 py-1 bg-light-gray/50 hover:bg-light-gray rounded-lg text-sm text-dark-gray" %>
+      <%= link_to t('views.simple_calendar.today'), calendar.url_for_today_view, class: "px-3 py-1 bg-green-100 hover:bg-green-200 rounded-lg text-sm text-green-700" %>
+      <%= link_to t('views.simple_calendar.next'), calendar.url_for_next_view, class: "px-3 py-1 bg-light-gray/50 hover:bg-light-gray rounded-lg text-sm text-dark-gray" %>
     </nav>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,10 @@ en:
         failed_delete: "We couldn't delete your comment."
 
   views:
+    simple_calendar:
+      previous: "previous"
+      today: "today"
+      next: "next"
     top:
       welcome: "Welcome back🏠"
       create_account: "Start by creating an account."
@@ -158,6 +162,7 @@ en:
       diary: "Exchange Diary　　　"
       place: "Favorite Places　　　"
       state: "Mental/Physical state"
+      calendar: "Calendar　　　　"
       message: "Greeting Message Settings"
       cleaning: "Tidy up the room"
     roommate:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -81,6 +81,10 @@ ja:
         delete: "コメントが削除されました"
         failed_delete: "コメントの削除に失敗しました"
   views:
+    simple_calendar:
+      previous: "先月"
+      today: "今月"
+      next: "来月"
     top:
       welcome: "おかえりなさい🍵"
       create_account: "まずはアカウントを作成しましょう。"
@@ -159,6 +163,7 @@ ja:
       diary: "交換日記　　　　　"
       place: "想い出スポット　　"
       state: "心身コンディション"
+      calendar: "カレンダー　　　　"
       message: "おかえり/ただいまメッセージ管理"
       cleaning: "部屋片づけ中"
     roommate:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
       resources :invitation_tokens, only: %i[create index update]
       resources :greetings, only: %i[new create index edit update destroy]
       resources :spots, only: %i[index new create show edit update destroy]
+      resources :calendars, only: %i[index new create show edit update destroy]
     end
 
     resources :areas, only: %i[create update index]

--- a/db/migrate/20250720141533_create_calendars.rb
+++ b/db/migrate/20250720141533_create_calendars.rb
@@ -10,12 +10,12 @@ class CreateCalendars < ActiveRecord::Migration[7.2]
       t.integer :all_day, null: false, default: 0
       t.integer :calendar_type, null: false, default: 0
       t.integer :visibility, null: false, default: 0
-      
+
       t.string :google_calendar_id
       t.string :google_event_id
       t.datetime :last_synced_at
       t.string :sync_token
-      
+
       t.timestamps null: false
 
       t.index :google_event_id, unique: true

--- a/db/migrate/20250720141533_create_calendars.rb
+++ b/db/migrate/20250720141533_create_calendars.rb
@@ -1,0 +1,24 @@
+class CreateCalendars < ActiveRecord::Migration[7.2]
+  def change
+    create_table :calendars do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :room, null: false, foreign_key: true
+      t.string :name, null: false
+      t.text :description
+      t.datetime :start_time
+      t.datetime :end_time
+      t.integer :all_day, null: false, default: 0
+      t.integer :calendar_type, null: false, default: 0
+      t.integer :visibility, null: false, default: 0
+      
+      t.string :google_calendar_id
+      t.string :google_event_id
+      t.datetime :last_synced_at
+      t.string :sync_token
+      
+      t.timestamps null: false
+
+      t.index :google_event_id, unique: true
+    end
+  end
+end

--- a/db/migrate/20250724043843_update_calendars_columns.rb
+++ b/db/migrate/20250724043843_update_calendars_columns.rb
@@ -1,0 +1,10 @@
+class UpdateCalendarsColumns < ActiveRecord::Migration[7.2]
+  def change
+    if column_exists?(:calendars, :calendar_type)
+      remove_column :calendars, :calendar_type
+    end
+    add_column :calendars, :source, :integer, null: false, default: 0
+    add_column :calendars, :category, :integer
+    rename_column :calendars, :all_day, :schedule_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_20_141533) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_24_043843) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,8 +39,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_20_141533) do
     t.text "description"
     t.datetime "start_time"
     t.datetime "end_time"
-    t.integer "all_day", default: 0, null: false
-    t.integer "calendar_type", default: 0, null: false
+    t.integer "schedule_type", default: 0, null: false
     t.integer "visibility", default: 0, null: false
     t.string "google_calendar_id"
     t.string "google_event_id"
@@ -48,6 +47,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_20_141533) do
     t.string "sync_token"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "source", default: 0, null: false
+    t.integer "category"
     t.index ["google_event_id"], name: "index_calendars_on_google_event_id", unique: true
     t.index ["room_id"], name: "index_calendars_on_room_id"
     t.index ["user_id"], name: "index_calendars_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_17_132842) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_20_141533) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,6 +30,27 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_17_132842) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_areas_on_user_id", unique: true
+  end
+
+  create_table "calendars", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "room_id", null: false
+    t.string "name", null: false
+    t.text "description"
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.integer "all_day", default: 0, null: false
+    t.integer "calendar_type", default: 0, null: false
+    t.integer "visibility", default: 0, null: false
+    t.string "google_calendar_id"
+    t.string "google_event_id"
+    t.datetime "last_synced_at"
+    t.string "sync_token"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["google_event_id"], name: "index_calendars_on_google_event_id", unique: true
+    t.index ["room_id"], name: "index_calendars_on_room_id"
+    t.index ["user_id"], name: "index_calendars_on_user_id"
   end
 
   create_table "exchange_diaries", force: :cascade do |t|
@@ -180,6 +201,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_17_132842) do
   add_foreign_key "answers", "posts"
   add_foreign_key "answers", "users"
   add_foreign_key "areas", "users"
+  add_foreign_key "calendars", "rooms"
+  add_foreign_key "calendars", "users"
   add_foreign_key "exchange_diaries", "rooms"
   add_foreign_key "exchange_diaries", "users"
   add_foreign_key "greetings", "rooms"

--- a/test/controllers/calendars_controller_test.rb
+++ b/test/controllers/calendars_controller_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class CalendarsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  def setup
+    @user = User.create!(name: "TestUserThree", email: "test3@example.com", password: "password3")
+    @room = Room.create!(user: @user, name: "room")
+    @calendar = Calendar.create!(user: @user, room: @room, name: "a", description: "a", start_time: "2025-07-24T14:19", end_time: "2025-07-24T14:49", schedule_type: 0, visibility: 0, source: 0, category: 0)
+    sign_in @user
+  end
+
+  test "should get index" do
+    get room_calendars_url(@room, locale: :ja)
+    assert_response :success
+  end
+end

--- a/test/fixtures/calendars.yml
+++ b/test/fixtures/calendars.yml
@@ -1,0 +1,32 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one:
+  user: one
+  room: one
+  name: a
+  description: a
+  start_time: 2025-07-24T14:19
+  end_time: 2025-07-24T14:49
+  schedule_type: 0
+  visibility: 0
+  source: 0
+  category: 0
+
+# column: value
+#
+two:
+  user: two
+  room: two
+  name: b
+  description: b
+  start_time: 2025-07-24T14:19
+  end_time: 2025-07-24T14:49
+  schedule_type: 0
+  visibility: 0
+  source: 0
+  category: 0
+# column: value


### PR DESCRIPTION
# 実装の流れ
1. 基本的なカレンダー機能
  - [x] 終日イベント時の処理
    - [x] モデルに記述（start_timeとend_timeそれぞれ0:00,23:59に自動保存)
    ```
    class Calendar < ApplicationRecord
      before_validation :adjust_all_day_times

      def all_day?
        schedule_type == "all_day"
      end
    
      private
    
      def adjust_all_day_times
        return unless all_day?
    
        if start_time.present?
          self.start_time = start_time.beginning_of_day
        end
    
        if end_time.present?
          self.end_time = end_time.end_of_day
        end
      end
    end
    ```
    ```
    date.beginning_of_day # 00:00
    date.end_of_day # 23:59
    ```
    - [x] コントローラで@calendar.save でデータベースに保存
    - [ ] start_timeがend_timeより前の時間にならないようvalidation追加
    - [x] viewファイルで入力フォーム＆送信記述
    - [x] 日時指定の時は月/日/時/分のフォーム（デフォルトは開始時間:現在・終了時間:現在＋30分)
    - [x] 終日の時は月/日のフォーム（デフォルトは開始日:今日・終了日:今日)
    - [x] 日時指定/終日の切り替え（JS）
3. フィルタリング機能
4. 共有機能
5. Googleカレンダー連携(別issue)
___
# 詳しい流れ
1. 手動カレンダー
2. フロントエンドでのカテゴリー切り替え
3. カレンダー表示用のヘルパー
4. カレンダー表示➡Simple Calendar gem
5. googleカレンダー連携➡gem 'google-api-client' / gem 'omniauth-google-oauth2'

# 実現したいこと
- カレンダー機能（googleカレンダー機能、手動でカレンダー作成）を作る
カレンダーの種類は、
  - 仕事、勉強
  - リラックス
  - 用事
にカテゴリー分けし、
共有段階は、
  - 個人のみ
  - ページを共有するメンバーと自分の予定共有
  - 予定自体がルームメイトと一緒にすること

「ページを共有するメンバーと自分の予定共有」か「予定自体がメンバーと一緒にすること」のとき、部屋のメンバーが閲覧可能なカレンダーに表示されるようにする

また、カレンダーの種類ごとに
toggleで表示内容を変えられるようにする。