### PR TITLE
Feature98/index calendars

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -7,6 +7,14 @@ class CalendarsController < ApplicationController
     @calendars = @room.calendars.includes(:user).order(created_at: :desc)
     @calendar_users = current_user.grouped_shared_users[@room.id] || []
     @today_state = current_user.state_calendars.find_by(room: @room, date: Date.current)
+
+    shared_calendars = @room.calendars.includes(:user).where(visibility: [ :share_only, :together ]).order(created_at: :desc)
+
+    if params[:category].present? && Calendar.categories.key?(params[:category])
+      @calendars = shared_calendars.where(category: Calendar.categories[params[:category]])
+    else
+      @calendars = shared_calendars
+    end
   end
 
   def new

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -3,6 +3,10 @@ class CalendarsController < ApplicationController
   before_action :set_room
 
   def index
+    @room = Room.find(params[:room_id])
+    @calendars = @room.calendars.includes(:user).order(created_at: :desc)
+    @calendar_users = current_user.grouped_shared_users[@room.id] || []
+    @today_state = current_user.state_calendars.find_by(room: @room, date: Date.current)
   end
 
   def new

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -31,6 +31,10 @@ class Calendar < ApplicationRecord
     end
   end
 
+  def calendar_date
+    start_time.to_date
+  end
+
   def all_day?
     schedule_type == "all_day"
   end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -13,6 +13,11 @@ class Calendar < ApplicationRecord
   enum visibility: { personal: 0, share_only: 1, together: 2 }
   enum category: { relax: 0, work_study: 1, event: 2 }
 
+  validates :schedule_type, presence: true
+  validates :visibility, presence: true
+  validates :category, presence: true
+  validates :name, presence: true
+
   def display_start_time
     if schedule_type == "all_day"
       start_time.strftime("%Y-%m-%d")

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -9,6 +9,7 @@ class Room < ApplicationRecord
   has_many :invitation_tokens
   has_many :greetings, dependent: :destroy
   has_many :spots, dependent: :destroy
+  has_many :calendars, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 30 }
 end

--- a/app/views/calendars/_form.html.erb
+++ b/app/views/calendars/_form.html.erb
@@ -1,0 +1,89 @@
+<div class="schedule-type-selection">
+  <%= f.radio_button :schedule_type, "timed", id: "schedule_type_timed", checked: true %>
+  <%= f.label :schedule_type_timed, "時間指定" %>
+
+  <%= f.radio_button :schedule_type, "all_day", id: "schedule_type_all_day" %>
+  <%= f.label :schedule_type_all_day, "終日" %>
+</div>
+
+<!-- 終日 -->
+<div id="all-day-fields" style="display: none;">
+  <div class="form-group">
+    <%= f.label :start_time, '開始日' %>
+    <%= f.date_field :start_time, value: (f.object.start_time || params[:date] || Date.today).to_date.strftime("%Y-%m-%d") %>
+  </div>
+  <div class="form-group">
+    <%= f.label :end_time, '終了日' %>
+    <%= f.date_field :end_time, value: (f.object.end_time || params[:date] || Date.today).to_date.strftime("%Y-%m-%d") %>
+  </div>
+</div>
+
+<!-- 時間指定　-->
+<div id="timed-fields">
+  <div class="form-group">
+    <%= f.label :start_time, '開始日時' %>
+    <%= f.datetime_local_field :start_time, class: 'form-control', value: (f.object.start_time || params[:datetime] || Time.current).strftime("%Y-%m-%dT%H:%M") %>
+  </div>
+  <div class="form-group">
+    <%= f.label :end_time, '終了日時' %>
+    <%= f.datetime_local_field :end_time, class: 'form-control', value: (f.object.end_time || params[:datetime] || (Time.current + 30.minutes)).strftime("%Y-%m-%dT%H:%M") %>
+  </div>
+</div>
+<div>
+  <%= f.label :name, "件名" %>
+  <%= f.text_field :name, placeholder: t("views.greeting.enter"), class: "w-full px-4 py-2 bg-light-gray/75 text-matcha rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
+
+  <%= f.label :source, "calendar_type", class: "text-dark-gray" %>
+  <%= f.select :source,
+    [["グーグル", "google"], ["マニュアル", "manual"]],
+    { prompt: "選んでください" }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha"
+  %>
+
+  <%= f.label :description, "note", class: "text-dark-gray" %>
+  <%= f.text_field :description, placeholder: "note", class: "w-full px-4 py-2 bg-light-gray/75 text-matcha rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
+
+  <%= f.label :category, "category", class: "text-dark-gray" %>
+  <%= f.select :category,
+    [["用事・その他", "event"], ["仕事・勉強", "work_study"],["リラックス", "relax"]],
+    { prompt: "選んでください" }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha"
+  %>
+
+  <%= f.label :visibility, "閲覧権限", class: "text-dark-gray" %>
+  <%= f.select :visibility,
+    [["自分だけ", "personal"], ["共有のみ", "share_only"],["一緒の予定", "together"]],
+    { prompt: "選んでください" }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha"
+  %>
+</div>
+<div class="text-center">
+  <%= f.submit t("buttons.save"), class: "bg-blue/75 text-dark-gray py-2 px-6 rounded hover:bg-blue/30 transition duration-200 mt-2", data: { turbo: false } %>
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const timedRadio = document.querySelector('#schedule_type_timed');
+    const allDayRadio = document.querySelector('#schedule_type_all_day');
+
+    const timedFields = document.getElementById('timed-fields');
+    const allDayFields = document.getElementById('all-day-fields');
+
+    function toggleFields() {
+      const isAllDay = allDayRadio.checked;
+
+      timedFields.style.display = isAllDay ? 'none' : 'block';
+      allDayFields.style.display = isAllDay ? 'block' : 'none';
+
+      // 各 input を有効・無効化
+      allDayFields.querySelectorAll('input').forEach(input => {
+        input.disabled = !isAllDay;
+      });
+      timedFields.querySelectorAll('input').forEach(input => {
+        input.disabled = isAllDay;
+      });
+    }
+
+    timedRadio.addEventListener('change', toggleFields);
+    allDayRadio.addEventListener('change', toggleFields);
+
+    toggleFields(); // 初期化
+  });
+</script>

--- a/app/views/calendars/_form.html.erb
+++ b/app/views/calendars/_form.html.erb
@@ -50,7 +50,7 @@
 
   <%= f.label :visibility, "閲覧権限", class: "text-dark-gray" %>
   <%= f.select :visibility,
-    [["自分だけ", "personal"], ["共有のみ", "share_only"],["一緒の予定", "together"]],
+    [["🔒非公開", "personal"], ["共有のみ", "share_only"],["一緒の予定", "together"]],
     { prompt: "選んでください" }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha"
   %>
 </div>

--- a/app/views/calendars/edit.html.erb
+++ b/app/views/calendars/edit.html.erb
@@ -1,0 +1,22 @@
+<%= link_to t("views.state_calendar.button"), room_calendars_path(@room), class: "bg-light-gray/75 p-4 rounded shadow mb-4" %>
+
+<% @calendars.each do |calendar| %>
+
+    <%= form_with model: [@room, calendar], local: true, class: "max-w-md mx-auto p-6 bg-light-gray/50 rounded-2xl shadow-lg mt-4" do |f| %>
+        <% if calendar.errors.any? %>
+            <div class="error-messages bg-red-100 text-red-700 p-4 mb-4 rounded">
+            <h2>入力エラーがあります：</h2>
+            <ul>
+                <% calendar.errors.full_messages.each do |msg| %>
+                <li><%= msg %></li>
+                <% end %>
+            </ul>
+            </div>
+        <% end %>
+        
+        <%= render partial: "form", locals: { f: f } %>
+        <%= link_to '<i class="fa-solid fa-trash text-lg text-blue"></i>'.html_safe, room_calendar_path(@room, calendar), data: { turbo_method: :delete, turbo_confirm: t("flash.alert")} %>
+    <% end %>
+<% end %>
+
+<%= link_to t("buttons.back"), room_calendars_path(@room), class: "bg-light-gray/75 py-2 px-6 rounded shadow mb-4 hover:bg-light-gray/50 transition text-dark-gray mt-4" %>

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -4,17 +4,25 @@
   <h2>今日の予定を表示</h2>
 <% end %>
 
+<div class="mb-4">
+  <strong>カテゴリフィルター：</strong>
+  <%= link_to 'すべて', room_calendars_path(@room), class: "mr-3 #{'text-matcha font-bold rounded bg-yellow' if params[:category].blank?}" %>
+  <%= link_to 'リラックス', room_calendars_path(@room, category: 'relax'), class: "mr-3 #{'text-matcha font-bold rounded bg-yellow' if params[:category] == 'relax'}" %>
+  <%= link_to '仕事・勉強', room_calendars_path(@room, category: 'work_study'), class: "mr-3 #{'text-matcha font-bold rounded bg-yellow' if params[:category] == 'work_study'}" %>
+  <%= link_to 'イベント', room_calendars_path(@room, category: 'event'), class: "#{'text-matcha font-bold rounded bg-yellow' if params[:category] == 'event'}" %>
+</div>
+
 <%= month_calendar(events: @calendars, attribute: :calendar_date) do |date, plans_on_day| %>
   <% if current_user %>
     <% if plans_on_day.present? %>
-      <% state_calendar = plans_on_day.find { |s| s.user_id == current_user.id } %>
-      <% if state_calendar %>
-        <%= link_to date.day, edit_room_state_calendar_path(@room, state_calendar, date: date), class: "block w-full h-full text-center" %>
+      <% calendar = plans_on_day.find { |s| s.user_id == current_user.id } %>
+      <% if calendar %>
+        <%= link_to date.day, edit_room_calendar_path(@room, calendar, date: date), class: "block w-full h-full text-center", data: { turbo: false } %>
       <% else %>
-        <%= link_to date.day, new_room_state_calendar_path(@room, date: date), class: "block w-full h-full text-center" %>
+        <%= link_to date.day, new_room_calendar_path(@room, date: date), class: "block w-full h-full text-center", data: { turbo: false } %>
       <% end %>
     <% else %>
-      <%= link_to date.day, new_room_state_calendar_path(@room, date: date), class: "block w-full h-full text-center" %>
+      <%= link_to date.day, new_room_calendar_path(@room, date: date), class: "block w-full h-full text-center", data: { turbo: false } %>
     <% end %>
   <% else %>
     <span><%= date.day %></span>
@@ -22,7 +30,14 @@
 
   <% plans_on_day.each do |state| %>
     <div class="text-xs leading-tight text-center">
-      <span class="inline-block px-0.5 py-0.5 rounded bg-yellow"><%= state.name %></span>
+      <% if state.category == "relax" %>
+        <span class="inline-block px-0.5 py-0.5 rounded bg-yellow"><%= state.name %></span>
+      <% elsif state.category == "work_study"  %>
+        <span class="inline-block px-0.5 py-0.5 rounded bg-pink-red/75"><%= state.name %></span>
+      <% else %>
+        <span class="inline-block px-0.5 py-0.5 rounded bg-matcha-green/50"><%= state.name %></span>
+      <% end %>
+        
       <span class="text-gray-600 text-[10px] block"><%= state.user.name %></span>
     </div>
   <% end %>

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -28,17 +28,30 @@
     <span><%= date.day %></span>
   <% end %>
 
-  <% plans_on_day.each do |state| %>
+  <% plans_on_day.each do |plan| %>
+    <% next unless plan.start_time.to_date == date %>
+    <% css_class = case plan.category
+      when "relax" then "bg-yellow"
+      when "work_study" then "bg-pink-red/75"
+      else "bg-matcha-green/50"
+    end %>
+
+    <% duration_days = (plan.end_time.to_date - plan.start_time.to_date).to_i + 1 %>
+
     <div class="text-xs leading-tight text-center">
-      <% if state.category == "relax" %>
-        <span class="inline-block px-0.5 py-0.5 rounded bg-yellow"><%= state.name %></span>
-      <% elsif state.category == "work_study"  %>
-        <span class="inline-block px-0.5 py-0.5 rounded bg-pink-red/75"><%= state.name %></span>
-      <% else %>
-        <span class="inline-block px-0.5 py-0.5 rounded bg-matcha-green/50"><%= state.name %></span>
+      <% if plan.start_time.to_date != plan.end_time.to_date %>
+        <div class="text-[10px] text-gray-500">
+          <%= l(plan.start_time.to_date, format: :short) %>〜<%= l(plan.end_time.to_date, format: :short) %>（<%= "#{duration_days}日" %>）
+        </div>
       <% end %>
-        
-      <span class="text-gray-600 text-[10px] block"><%= state.user.name %></span>
+      <% if plan.user == current_user %>
+        <span class="inline-block px-0.5 py-0.5 rounded <%= css_class %>"><%= plan.name %></span>
+      <% else %>
+        <%= link_to room_calendar_path(@room, plan), class: "inline-block px-0.5 py-0.5 rounded #{css_class}" do %>
+          <%= plan.name %>
+        <% end %>
+      <% end %>
+      <span class="text-gray-600 text-[10px] block"><%= plan.user.name %></span>
     </div>
   <% end %>
 <% end %>

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -1,4 +1,33 @@
-<h1>どうも</h1>
+<h1 class="text-matcha-green text-xl font-bold mt-6"><%= @room.name %>のカレンダー</h1>
+
+<% unless @today_state.present? %>
+  <h2>今日の予定を表示</h2>
+<% end %>
+
+<%= month_calendar(events: @calendars, attribute: :calendar_date) do |date, plans_on_day| %>
+  <% if current_user %>
+    <% if plans_on_day.present? %>
+      <% state_calendar = plans_on_day.find { |s| s.user_id == current_user.id } %>
+      <% if state_calendar %>
+        <%= link_to date.day, edit_room_state_calendar_path(@room, state_calendar, date: date), class: "block w-full h-full text-center" %>
+      <% else %>
+        <%= link_to date.day, new_room_state_calendar_path(@room, date: date), class: "block w-full h-full text-center" %>
+      <% end %>
+    <% else %>
+      <%= link_to date.day, new_room_state_calendar_path(@room, date: date), class: "block w-full h-full text-center" %>
+    <% end %>
+  <% else %>
+    <span><%= date.day %></span>
+  <% end %>
+
+  <% plans_on_day.each do |state| %>
+    <div class="text-xs leading-tight text-center">
+      <span class="inline-block px-0.5 py-0.5 rounded bg-yellow"><%= state.name %></span>
+      <span class="text-gray-600 text-[10px] block"><%= state.user.name %></span>
+    </div>
+  <% end %>
+<% end %>
 
 <%= link_to t("views.room.back_to_room", room_name: @room.name), room_path(@room), class: "bg-brown/30 p-2 rounded shadow mb-2 mt-4 text-brown font-bold hover:bg-brown/70 transition", data: { turbo: false } %>
-<%= link_to t("buttons.new"), new_room_calendar_path(), class: "bg-blue/75 p-4 rounded shadow mb-4 mt-2 hover:bg-blue-30 transition text-dark-gray", data: { turbo: false } %>
+
+<%= link_to t("buttons.new"), new_room_calendar_path(@room), class: "bg-blue/75 p-4 rounded shadow mb-4 mt-2 hover:bg-blue-30 transition text-dark-gray", data: { turbo: false } %>

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -6,10 +6,13 @@
 
 <div class="mb-4">
   <strong>カテゴリフィルター：</strong>
-  <%= link_to 'すべて', room_calendars_path(@room), class: "mr-3 #{'text-matcha font-bold rounded bg-yellow' if params[:category].blank?}" %>
-  <%= link_to 'リラックス', room_calendars_path(@room, category: 'relax'), class: "mr-3 #{'text-matcha font-bold rounded bg-yellow' if params[:category] == 'relax'}" %>
-  <%= link_to '仕事・勉強', room_calendars_path(@room, category: 'work_study'), class: "mr-3 #{'text-matcha font-bold rounded bg-yellow' if params[:category] == 'work_study'}" %>
-  <%= link_to 'イベント', room_calendars_path(@room, category: 'event'), class: "#{'text-matcha font-bold rounded bg-yellow' if params[:category] == 'event'}" %>
+  <%= link_to 'すべて', room_calendars_path(@room), class: "mr-3 #{'text-matcha font-bold rounded bg-yellow' if params[:category].blank? && params[:visibility].blank? }" %>
+  <%= link_to '/リラックス', room_calendars_path(@room, category: 'relax'), class: "mr-3 #{'text-matcha font-bold rounded bg-yellow' if params[:category] == 'relax'}" %>
+  <%= link_to '/仕事・勉強', room_calendars_path(@room, category: 'work_study'), class: "mr-3 #{'text-matcha font-bold rounded bg-yellow' if params[:category] == 'work_study'}" %>
+  <%= link_to '/イベント', room_calendars_path(@room, category: 'event'), class: "#{'text-matcha font-bold rounded bg-yellow' if params[:category] == 'event'}" %>
+  <% if current_user.calendars.exists?(visibility: 'personal') %>
+    <%= link_to '/🔒個人予定管理', room_calendars_path(@room, visibility: 'personal'), class: "#{'text-matcha font-bold rounded bg-yellow' if params[:visibility] == 'personal'}" %>
+  <% end %>
 </div>
 
 <%= month_calendar(events: @calendars, attribute: :calendar_date) do |date, plans_on_day| %>
@@ -30,6 +33,11 @@
 
   <% plans_on_day.each do |plan| %>
     <% next unless plan.start_time.to_date == date %>
+
+    <% if plan.user == current_user && plan.visibility != 'personal' && params[:visibility] == 'personal' %>
+      <% next %>
+    <% end %>
+
     <% css_class = case plan.category
       when "relax" then "bg-yellow"
       when "work_study" then "bg-pink-red/75"
@@ -39,11 +47,6 @@
     <% duration_days = (plan.end_time.to_date - plan.start_time.to_date).to_i + 1 %>
 
     <div class="text-xs leading-tight text-center">
-      <% if plan.start_time.to_date != plan.end_time.to_date %>
-        <div class="text-[10px] text-gray-500">
-          <%= l(plan.start_time.to_date, format: :short) %>〜<%= l(plan.end_time.to_date, format: :short) %>（<%= "#{duration_days}日" %>）
-        </div>
-      <% end %>
       <% if plan.user == current_user %>
         <span class="inline-block px-0.5 py-0.5 rounded <%= css_class %>"><%= plan.name %></span>
       <% else %>
@@ -51,7 +54,12 @@
           <%= plan.name %>
         <% end %>
       <% end %>
-      <span class="text-gray-600 text-[10px] block"><%= plan.user.name %></span>
+      <% if plan.start_time.to_date != plan.end_time.to_date %>
+        <div class="text-[10px] text-matcha">
+          <%= l(plan.start_time.to_date, format: :short) %>-<%= l(plan.end_time.to_date, format: :short) %>（<%= "#{duration_days}日" %>）
+        </div>
+      <% end %>
+        <span class="text-gray-600 text-[10px] block"><%= plan.user.name %></span>
     </div>
   <% end %>
 <% end %>

--- a/app/views/calendars/new.html.erb
+++ b/app/views/calendars/new.html.erb
@@ -21,11 +21,11 @@
   <div id="all-day-fields" style="display: none;">
     <div class="form-group">
       <%= f.label :start_time, '開始日' %>
-      <%= f.date_field :start_time, class: 'form-control', value: Time.current.strftime("%Y-%m-%d") %>
+      <%= f.date_field :start_time, class: 'form-control', value: (params[:date] || f.object.start_time || Date.today).to_date.strftime("%Y-%m-%d") %>
     </div>
     <div class="form-group">
       <%= f.label :end_time, '終了日' %>
-      <%= f.date_field :end_time, class: 'form-control', value: Time.current.strftime("%Y-%m-%d") %>
+      <%= f.date_field :end_time, class: 'form-control', value: (params[:date] || f.object.end_time || Date.today).to_date.strftime("%Y-%m-%d") %>
     </div>
   </div>
 

--- a/app/views/calendars/new.html.erb
+++ b/app/views/calendars/new.html.erb
@@ -1,3 +1,5 @@
+<%= link_to t("views.state_calendar.button"), room_calendars_path(@room), class: "bg-light-gray/75 p-4 rounded shadow mb-4" %>
+
 <%= form_with model: [@room, @calendar], local: true, class: "max-w-md mx-auto p-6 bg-light-gray/50 rounded-2xl shadow-lg mt-2" do |f| %>
   <% if @calendar.errors.any? %>
     <div class="error-messages bg-red-100 text-red-700 p-4 mb-4 rounded">
@@ -9,97 +11,7 @@
       </ul>
     </div>
   <% end %>
-  <div class="schedule-type-selection">
-    <%= f.radio_button :schedule_type, "timed", id: "schedule_type_timed", checked: true %>
-    <%= f.label :schedule_type_timed, "時間指定" %>
-
-    <%= f.radio_button :schedule_type, "all_day", id: "schedule_type_all_day" %>
-    <%= f.label :schedule_type_all_day, "終日" %>
-  </div>
-
-  <!-- 終日 -->
-  <div id="all-day-fields" style="display: none;">
-    <div class="form-group">
-      <%= f.label :start_time, '開始日' %>
-      <%= f.date_field :start_time, class: 'form-control', value: (params[:date] || f.object.start_time || Date.today).to_date.strftime("%Y-%m-%d") %>
-    </div>
-    <div class="form-group">
-      <%= f.label :end_time, '終了日' %>
-      <%= f.date_field :end_time, class: 'form-control', value: (params[:date] || f.object.end_time || Date.today).to_date.strftime("%Y-%m-%d") %>
-    </div>
-  </div>
-
-  <!-- 時間指定　-->
-  <div id="timed-fields">
-    <div class="form-group">
-      <%= f.label :start_time, '開始日時' %>
-      <%= f.datetime_local_field :start_time, class: 'form-control', value: Time.current.strftime("%Y-%m-%dT%H:%M") %>
-    </div>
-    <div class="form-group">
-      <%= f.label :end_time, '終了日時' %>
-      <%= f.datetime_local_field :end_time, class: 'form-control', value: (Time.current + 30.minutes).strftime("%Y-%m-%dT%H:%M") %>
-    </div>
-  </div>
-
-  <div>
-    <%= f.label :name, "件名" %>
-    <%= f.text_field :name, placeholder: t("views.greeting.enter"), class: "w-full px-4 py-2 bg-light-gray/75 text-matcha rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
-
-    <%= f.label :source, "calendar_type", class: "text-dark-gray" %>
-    <%= f.select :source,
-      [["グーグル", "google"], ["マニュアル", "manual"]],
-      { prompt: "選んでください" }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha"
-    %>
-
-    <%= f.label :description, "note", class: "text-dark-gray" %>
-    <%= f.text_field :description, placeholder: "note", class: "w-full px-4 py-2 bg-light-gray/75 text-matcha rounded-lg focus:outline-none focus:ring-2 focus:ring-matcha" %>
-
-    <%= f.label :category, "category", class: "text-dark-gray" %>
-    <%= f.select :category,
-      [["用事・その他", "event"], ["仕事・勉強", "work_study"],["リラックス", "relax"]],
-      { prompt: "選んでください" }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha"
-    %>
-
-    <%= f.label :visibility, "閲覧権限", class: "text-dark-gray" %>
-    <%= f.select :visibility,
-      [["自分だけ", "personal"], ["共有のみ", "share_only"],["一緒の予定", "together"]],
-      { prompt: "選んでください" }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha"
-    %>
-  </div>
-  <div class="text-center">
-    <%= f.submit t("buttons.save"), class: "bg-blue/75 text-dark-gray py-2 px-6 rounded hover:bg-blue/30 transition duration-200 mt-2", data: { turbo: false } %>
-  </div>
+  <%= render partial: "form", locals: { f: f } %>
 <% end %>
 
-<%= link_to t("buttons.back"), room_calendars_path(@room), class: "bg-light-gray/75 py-2 px-6 rounded shadow mb-4 hover:bg-light-gray/50 transition text-dark-gray" %>
-
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    const timedRadio = document.querySelector('#schedule_type_timed');
-    const allDayRadio = document.querySelector('#schedule_type_all_day');
-
-    const timedFields = document.getElementById('timed-fields');
-    const allDayFields = document.getElementById('all-day-fields');
-
-    function toggleFields() {
-      const isAllDay = allDayRadio.checked;
-
-      timedFields.style.display = isAllDay ? 'none' : 'block';
-      allDayFields.style.display = isAllDay ? 'block' : 'none';
-
-      // 各 input を有効・無効化
-      allDayFields.querySelectorAll('input').forEach(input => {
-        input.disabled = !isAllDay;
-      });
-      timedFields.querySelectorAll('input').forEach(input => {
-        input.disabled = isAllDay;
-      });
-    }
-
-    timedRadio.addEventListener('change', toggleFields);
-    allDayRadio.addEventListener('change', toggleFields);
-
-    toggleFields(); // 初期化
-  });
-</script>
-
+<%= link_to t("buttons.back"), room_calendars_path(@room), class: "bg-light-gray/75 py-2 px-6 rounded shadow mb-4 hover:bg-light-gray/50 transition text-dark-gray mt-4" %>

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -1,0 +1,45 @@
+<%= link_to t("views.state_calendar.button"), room_calendars_path(@room), class: "bg-light-gray/75 p-4 rounded shadow mb-4" %>
+
+<div class="bg-light-gray/75 p-4 rounded shadow mb-4">
+
+  <p class="text-dark-gray mb-2">
+    <strong><%= t("views.state_calendar.mental_state") %>:</strong>
+    <% if @calendar.start_time.to_date == @calendar.end_time.to_date %>
+      <span class="inline-block px-2 py-1 rounded bg-yellow text-dark-gray">
+        終日：<%= @calendar.display_start_time %>
+      </span>
+    <% else %>
+      <span class="inline-block px-2 py-1 rounded bg-yellow text-dark-gray">
+        開始：<%= @calendar.display_start_time %>
+      </span>
+      <span class="inline-block px-2 py-1 rounded bg-yellow text-dark-gray">
+        終了：<%= @calendar.display_end_time %>
+      </span>
+    <% end %>
+  </p>
+
+  <p class="text-dark-gray mb-2">
+    <strong><%= t("views.state_calendar.physical_state") %>:</strong>
+    <span class="inline-block px-2 py-1 rounded bg-light-blue/30 text-dark-gray">
+      <%= @calendar.name %>
+    </span>
+  </p>
+  
+  <% if @calendar.description.present? %>
+    <p class="text-dark-gray mb-2">
+        <%= @calendar.description %>
+    </p>
+  <% else %>
+    <h1>メモ📝はありません</h1>
+  <% end %>
+
+  <div class="text-dark-gray mb-2">
+    <p><%= @calendar.visibility%></p>
+    <p><%= @calendar.category%></p>
+  </div>
+
+</div>
+
+<div class="flex justify-center">
+  <%= link_to t("views.room.back_to_room", room_name: @room.name), room_path(@room), class: "bg-brown/30 p-2 rounded shadow mt-4 text-brown font-bold hover:bg-brown/70 transition" %>
+</div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -24,7 +24,7 @@
       <% date_range.each_slice(7) do |week| %>
         <tr>
           <% week.each do |day| %>
-            <%= content_tag :td, class: "#{calendar.td_classes_for(day)} border p-2 align-top hover:bg-light-blue/50 transition duration-200 ease-in-out #{'bg-blue text-dark-gray font-semibold' if day == Date.current}" do %>
+            <%= content_tag :td, class: "#{calendar.td_classes_for(day)} border p-2 align-top hover:bg-light-blue/50 transition duration-200 ease-in-out #{'bg-blue/75 text-dark-gray font-semibold' if day == Date.current}" do %>
               <% events = calendar.sorted_events_for(day) %>
               <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
             <% end %>


### PR DESCRIPTION
# 実装の流れ
1. 基本的なカレンダー機能
  - [x] 終日イベント時の処理
    - [x] モデルに記述（start_timeとend_timeそれぞれ0:00,23:59に自動保存)
    ```
    class Calendar < ApplicationRecord
      before_validation :adjust_all_day_times

      def all_day?
        schedule_type == "all_day"
      end
    
      private
    
      def adjust_all_day_times
        return unless all_day?
    
        if start_time.present?
          self.start_time = start_time.beginning_of_day
        end
    
        if end_time.present?
          self.end_time = end_time.end_of_day
        end
      end
    end
    ```
    ```
    date.beginning_of_day # 00:00
    date.end_of_day # 23:59
    ```
    - [x] コントローラで@calendar.save でデータベースに保存
    - [x] start_timeがend_timeより前の時間にならないようvalidation追加
    - [x] viewファイルで入力フォーム＆送信記述
    - [x] 日時指定の時は月/日/時/分のフォーム（デフォルトは開始時間:現在・終了時間:現在＋30分)
    - [x] 終日の時は月/日のフォーム（デフォルトは開始日:今日・終了日:今日)
    - [x] 日時指定/終日の切り替え（JS）
 ___
# 残ったタスク
- [x] フィルタリング機能
- [ ] 共有機能
5. Googleカレンダー連携(別issue)
___
# 詳しい流れ
1. 手動カレンダー
2. フロントエンドでのカテゴリー切り替え
3. カレンダー表示用のヘルパー
4. カレンダー表示➡Simple Calendar gem
5. googleカレンダー連携➡gem 'google-api-client' / gem 'omniauth-google-oauth2'

# 実現したいこと
- カレンダー機能（googleカレンダー機能、手動でカレンダー作成）を作る
カレンダーの種類は、
  - 仕事、勉強
  - リラックス
  - 用事
にカテゴリー分けし、
共有段階は、
  - 個人のみ
  - ページを共有するメンバーと自分の予定共有
  - 予定自体がルームメイトと一緒にすること

「ページを共有するメンバーと自分の予定共有」か「予定自体がメンバーと一緒にすること」のとき、部屋のメンバーが閲覧可能なカレンダーに表示されるようにする

また、カレンダーの種類ごとに
toggleで表示内容を変えられるようにする。