### PR TITLE
fix/flash_calendar_input

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -131,10 +131,10 @@ class CalendarsController < ApplicationController
     end
     current_user.update!(sync_token: response.next_sync_token)
   end
-    redirect_to room_calendars_path(@room), notice: t("flash.state_calendar.input")
+    redirect_to room_calendars_path(@room), notice: t("flash.calendar.input")
   rescue => e
     logger.error "Import failed: #{e.message}"
-    flash.now[:alert] = t("flash.state_calendar.failed_input")
+    flash.now[:alert] = t("flash.calendar.failed_input")
     render :index, status: :unprocessable_entity
   end
 


### PR DESCRIPTION
# フラッシュメッセージの修正

```
t("flash.state_calendar.failed_input")
上記を以下に修正しました。

t("flash.calendar.failed_input")
```