### PR TITLE
fix/terms_of_service

### DIFF
--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,4 +1,4 @@
-<div class="text-center text-2xl font-bold underline mt-4"><%= t("views.footer.terms") %></div>
+<div class="text-center text-2xl font-bold underline mt-4"><%= t("views.footer.terms_of_service") %></div>
 <div class="flex justify-center mt-8">
   <div class="text-left max-w-2xl w-full">
     <p>


### PR DESCRIPTION
# terms_of_serviceの翻訳呼び出しのエラー修正
```
<div class="text-center text-2xl font-bold underline mt-4"><%= t("views.footer.terms") %></div>
⇩上記を以下に変更
<div class="text-center text-2xl font-bold underline mt-4"><%= t("views.footer.terms_of_service") %></div>
```