### PR TITLE
suspend_google_calendar

### DIFF
--- a/app/views/calendars/_form.html.erb
+++ b/app/views/calendars/_form.html.erb
@@ -35,7 +35,7 @@
 
   <%= f.label :source, t('activerecord.attributes.calendar.source'), class: "text-dark-gray" %>
   <%= f.select :source,
-    [[t('views.calendar.google'), "google"], [t('views.calendar.manual'), "manual"]],
+    [[t('views.calendar.manual'), "manual"]],
     { prompt: t('views.calendar.select') }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha"
   %>
 

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -1,12 +1,8 @@
 <h1 class="text-matcha-green text-xl font-bold mt-6"><%= t('views.calendar.calendar_name', name: @room.name) %></h1>
 
-<% unless @today_state.present? %>
-  <h2>今日の予定を表示</h2>
-<% end %>
+<!--%= button_to t('views.calendar.google_calendar'), import_room_calendars_path(@room), method: :post, class: "bg-blue/75 p-4 rounded shadow mb-4 mt-2 hover:bg-blue-30 transition text-dark-gray btn btn-primary", data: { turbo: false } %>-->
 
-<%= button_to t('views.calendar.google_calendar'), import_room_calendars_path(@room), method: :post, class: "bg-blue/75 p-4 rounded shadow mb-4 mt-2 hover:bg-blue-30 transition text-dark-gray btn btn-primary", data: { turbo: false } %>
-
-<div class="mb-4">
+<div class="mb-4 mt-6">
   <strong><%= t('views.calendar.category_filter') %>：</strong>
   <%= link_to t('views.calendar.all'), room_calendars_path(@room), class: "mr-3 #{'text-matcha font-bold rounded bg-yellow' if params[:category].blank? && params[:visibility].blank? }" %>
   <%= link_to t('views.calendar.relax'), room_calendars_path(@room, category: 'relax'), class: "mr-3 #{'text-matcha font-bold rounded bg-yellow' if params[:category] == 'relax'}" %>
@@ -68,4 +64,4 @@
 
 <%= link_to t("views.room.back_to_room", room_name: @room.name), room_path(@room), class: "bg-brown/30 p-2 rounded shadow mb-2 mt-4 text-brown font-bold hover:bg-brown/70 transition", data: { turbo: false } %>
 
-<%= link_to t("buttons.new"), new_room_calendar_path(@room), class: "bg-blue/75 p-4 rounded shadow mb-4 mt-2 hover:bg-blue-30 transition text-dark-gray", data: { turbo: false } %>
+<%= link_to t("buttons.add_today"), new_room_calendar_path(@room), class: "bg-blue/75 p-4 rounded shadow mb-4 mt-2 hover:bg-blue-30 transition text-dark-gray", data: { turbo: false } %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -16,7 +16,7 @@
           <%= link_to t('devise.registrations.sign_up'), new_user_registration_path, data: { turbo: false } %>
           <%= button_to user_google_oauth2_omniauth_authorize_path(locale: nil), class: 'btn',data: { turbo: false } do %>
             <img src="https://www.svgrepo.com/show/475656/google-color.svg" class="w-4 h-4" alt="google logo">
-            <span>Login with Google(メンテナンス中)</span>
+            <span>Login with Google</span>
           <% end %>
         </div>
       </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -27,9 +27,14 @@ Devise.setup do |config|
   config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
 
   config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], {
-    scope: "email, profile, https://www.googleapis.com/auth/calendar.readonly",
-    prompt: "consent select_account", access_type: "offline"
+    scope: "email,profile",
+    prompt: "select_account"
   }
+
+  # config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], {
+  #   scope: "email, profile, https://www.googleapis.com/auth/calendar.readonly",
+  #   prompt: "consent select_account", access_type: "offline"
+  # }
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
     register: "Register"
     save_new: "Save"
     add: "Add"
+    add_today: "Add Today's schedule"
   flash:
     alert: "Are you sure you'd like to delete this?"
     diary:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,6 +8,7 @@ ja:
     register: "登録"
     save_new: "登録"
     add: "追加"
+    add_today: "今日の予定を追加"
   flash:
     alert: "本当に削除しますか？"
     diary:


### PR DESCRIPTION
# google calendar認可申請まで退避
-  config/initializers/devise.rb
  - google calendarがテストユーザーで使用可能なことを確認、google認可で本番使用可能になるまで退避
```
config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], {
    scope: "email,profile",
    prompt: "select_account"
  }

  # config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], {
  #   scope: "email, profile, https://www.googleapis.com/auth/calendar.readonly",
  #   prompt: "consent select_account", access_type: "offline"
  # }
```
- app/views/calendars/index.html.erb
  - google calendar連携ボタンをコメントアウト

- app/views/calendars/_form.html.erb
  - 新規・編集フォームの「google」選択肢を一時退避
```
<%= f.label :source, t('activerecord.attributes.calendar.source'), class: "text-dark-gray" %>
  <%= f.select :source,
    [[t('views.calendar.google'), "google"], [t('views.calendar.manual'), "manual"]],
    { prompt: t('views.calendar.select') }, class: "bg-matcha/65 text-beige py-2 pl-3 pr-10 rounded w-full focus:ring-2 focus:ring-matcha"
  %>

# 上記のカレンダー部分[t('views.calendar.google'), "google"]を退避
```