### PR TITLE
fix_calendar_date

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -37,7 +37,9 @@ class CalendarsController < ApplicationController
 
   def new
     @room = Room.find(params[:room_id])
-    @calendar = current_user.calendars.find_by(room: @room, start_time: params[:start_time]) || current_user.calendars.new(room: @room, start_time: params[:start_time] || Date.current)
+    start_time = (params[:date].presence && Date.parse(params[:date])) || Date.current
+    @calendar = current_user.calendars.find_by(room: @room, start_time: start_time) ||
+            current_user.calendars.new(room: @room, start_time: start_time)
   end
 
   def create

--- a/app/views/calendars/_form.html.erb
+++ b/app/views/calendars/_form.html.erb
@@ -10,17 +10,13 @@
 <div id="all-day-fields" style="display: none;">
   <div class="form-group">
     <%= f.label :start_time, t('activerecord.attributes.calendar.start_date') %>
-    <%= f.date_field :start_time, value: (
-        f.object.start_time ||
-        (params[:date].present? ? Date.parse(params[:date]) : Date.today)
-      ).to_date.strftime("%Y-%m-%d") %>
+    <%= f.date_field :start_time, value: @calendar.start_time&.to_date || Date.current, class: "text-dark-gray bg-matcha/30" %>
   </div>
   <div class="form-group">
     <%= f.label :end_time, t('activerecord.attributes.calendar.end_date') %>
     <%= f.date_field :end_time, value: (
-        f.object.end_time ||
-        (params[:date].present? ? Date.parse(params[:date]) : Date.today)
-      ).to_date.strftime("%Y-%m-%d") %>
+          (f.object.end_time || f.object.start_time || (params[:date].present? ? Date.parse(params[:date]) : Date.today))
+          ).to_date.strftime("%Y-%m-%d"), class: "text-dark-gray bg-matcha/30" %>
   </div>
 </div>
 
@@ -28,14 +24,15 @@
 <div id="timed-fields">
   <div class="form-group">
     <%= f.label :start_time, t('activerecord.attributes.calendar.start_time') %>
-    <%= f.datetime_local_field :start_time, class: 'form-control', value: (
-        f.object.start_time ||
-        (params[:datetime].present? ? Date.parse(params[:datetime]) : Date.today)
-      ).strftime("%Y-%m-%dT%H:%M") %>
+    <%= f.datetime_local_field :start_time, value: @calendar.start_time&.to_date || Date.current, class: "text-dark-gray bg-matcha/30" %>
   </div>
   <div class="form-group">
     <%= f.label :end_time, t('activerecord.attributes.calendar.end_time') %>
-    <%= f.datetime_local_field :end_time, class: 'form-control', value: (f.object.end_time || (Date.parse(params[:datetime]) rescue (Time.current + 30.minutes))).strftime("%Y-%m-%dT%H:%M") %>
+    <%= f.datetime_local_field :end_time, value: (
+          (f.object.end_time ||
+           (f.object.start_time ? f.object.start_time + 30.minutes : nil) ||
+           (params[:datetime].present? ? Date.parse(params[:datetime]) : Time.current + 30.minutes))
+          ).strftime("%Y-%m-%dT%H:%M"), class: "text-dark-gray bg-matcha/30" %>
   </div>
 </div>
 <div>


### PR DESCRIPTION
# カレンダー新規作成時の時間表示を修正
- 目標
  - カレンダーの日付を押すと、その日付で新しく作成ができる
  - 終日は開始・終了日が同一（初期値）
  - 時間指定を押すと、終了時間が開始時間と同日の30分後を指定（初期値）
-  エラー時
  - カレンダーの日付を押すと、どの日付を押しても「今日の日付」になってしまう
___
- calendarコントローラのnewアクションで、start_timeの定義をしました
- calendarのformビューファイルで、start_timeに@calendar.start_timeを用いて初期値を入れました
- calendarのformビューファイルで、終日のend_timeは上記のstart_timeを利用して同日になるようにしました
- calendarのformビューファイルで、時間指定のend_timeは上記のstart_timeを利用して同日かつstart_timeの３０分後になるようにしました
