### PR TITLE
update_link_entrance

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,10 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :update_last_seen, if: :user_signed_in?
 
+  def after_sign_in_path_for(resource)
+    rooms_path
+  end
+
   def set_locale
     I18n.locale = params[:locale] || I18n.default_locale
   end
@@ -25,6 +29,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
-    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ]) # ←これがnameの編集に必要！
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -63,7 +63,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # The path used after sign up.
   def after_sign_up_path_for(resource)
-    root_path
+    rooms_path
   end
 
   # The path used after sign up for inactive accounts.

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -3,7 +3,7 @@
     <div class="pointer-events-auto flex flex-col lg:flex-row justify-center items-start gap-6 max-w-7xl w-full">
       <% if @rooms.empty? %>
         <div class="pointer-events-auto flex flex-col justify-center items-center gap-6 max-w-4xl w-full mx-auto">
-          <div class="text-gray text-center text-lg"><%= t("flash.room.no_room") %></div>
+          <div class="text-gray text-center text-lg animate-bounce"><%= t("flash.room.no_room") %></div>
           <div class="max-w-xl w-full">
             <%= render 'form_room' %>
           </div>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,4 +1,4 @@
-<section class="w-full mx-auto max-w-2xl lg:max-w-full h-auto flex items-center justify-center mt-2 relative overflow-hidden">
+<section class="w-full mx-auto max-w-2xl lg:max-w-full h-auto flex items-center justify-center mt-6 relative overflow-hidden px-6 lg:px-24">
   <img src="/room.jpg" alt="" class="w-full h-auto object-contain object-center" />
   <div class="absolute inset-0 flex flex-col items-center justify-center text-white p-6 rounded">
     <h1 class="text-2xl mb-4"><%= t("views.top.welcome") %></h1>
@@ -10,7 +10,7 @@
   <p class="mb-2"><%= t("views.top.messages.two") %></p>
   <p class="mb-4"><%= t("views.top.messages.three") %></p>
 </section>
-<section class="min-h-screen w-full flex items-center justify-center bg-white px-4">
+<section class="px-4 py-12 w-full flex items-center justify-center bg-white px-4">
   <div class="flex flex-col md:flex-row items-center justify-center max-w-5xl w-full gap-8" data-aos="fade-up">
     <div class="w-full md:w-1/2">
       <%= image_tag '/registration.png', class: 'w-full h-auto rounded shadow-md' %>
@@ -25,7 +25,7 @@
   </div>
 </section>
 
-<section class="min-h-screen w-full flex items-center justify-center bg-gray-100">
+<section class="px-4 py-12 w-full flex items-center justify-center bg-gray-100">
   <div class="flex flex-col md:flex-row items-center justify-center max-w-5xl w-full gap-8" data-aos="fade-up">
     <div class="w-full md:w-1/2 text-center md:text-right">
       <h1 class="text-4xl font-semibold mb-4">Step 2</h1>
@@ -41,7 +41,7 @@
   </div>
 </section>
 
-<section class="min-h-screen w-full flex items-center justify-center bg-white">
+<section class="px-4 py-12 w-full flex items-center justify-center bg-white">
   <div class="flex flex-col md:flex-row items-center justify-center max-w-5xl w-full gap-8" data-aos="fade-up">
     <div class="w-full md:w-1/2">
       <%= image_tag '/area.gif', class: 'w-full h-auto rounded shadow-md' %>
@@ -56,7 +56,7 @@
   </div>
 </section>
 
-<section class="min-h-screen w-full flex items-center justify-center bg-gray-100">
+<section class="px-4 py-12 w-full flex items-center justify-center bg-gray-100">
   <div class="flex flex-col md:flex-row items-center justify-center max-w-5xl w-full gap-8" data-aos="fade-up">
     <div class="w-full md:w-1/2 text-center md:text-right">
       <h1 class="text-4xl font-semibold mb-4">Step 4</h1>
@@ -74,7 +74,7 @@
   </div>
 </section>
 
-<section class="min-h-screen w-full flex items-center justify-center bg-white">
+<section class="px-4 py-12 w-full flex items-center justify-center bg-white">
   <div class="text-center px-6" data-aos="fade-up">
     <h2 class="text-3xl font-bold mb-4">Step 5</h2>
     <p class="text-base text-gray-600"><%= t("views.top.daily_life") %><br><%= t("views.top.seven_features") %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,7 +25,7 @@ en:
 
     room:
       failed_find: "The room could not be found."
-      no_room: "You haven't registered any rooms yet."
+      no_room: "⇩Start by creating a room"
       no_area: "Your location hasn't been registered yet."
     rooms:
       none_access: "Looks like you don’t have access to this room."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,7 +25,7 @@ ja:
 
     room:
       failed_find: "部屋が見つかりませんでした"
-      no_room: "登録部屋はまだありません"
+      no_room: "⇩まずはお家を作成"
     rooms:
       none_access: "この部屋にアクセスできません"
       return: "ただいま！"


### PR DESCRIPTION
# ログイン後の遷移先変更/TOPページの余白を削除

(前)ログイン後、TOPページに遷移していました。
  - (今回)ログイン後room/showページ（玄関）に遷移するようにし、すぐに部屋作成ができる導線に変更しました。
(前)TOPページの使い方説明が、それぞれ上下の余白が大きくスクロール量が多い
- (今回)上下の余白を追加し、スクロールのストレスを軽減させるようにしました。