### PR TITLE
update/google_calendar_uniqueness

### DIFF
--- a/db/migrate/20250813072700_change_google_event_id_index_on_calendars.rb
+++ b/db/migrate/20250813072700_change_google_event_id_index_on_calendars.rb
@@ -1,0 +1,9 @@
+class ChangeGoogleEventIdIndexOnCalendars < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :calendars, name: "index_calendars_on_google_event_id"
+
+    add_index :calendars, [ :room_id, :google_event_id ],
+              unique: true,
+              name: "index_calendars_on_room_id_and_google_event_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_02_091316) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_13_072700) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,7 +48,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_02_091316) do
     t.datetime "updated_at", null: false
     t.integer "source", default: 0, null: false
     t.integer "category"
-    t.index ["google_event_id"], name: "index_calendars_on_google_event_id", unique: true
+    t.index ["room_id", "google_event_id"], name: "index_calendars_on_room_id_and_google_event_id", unique: true
     t.index ["room_id"], name: "index_calendars_on_room_id"
     t.index ["user_id"], name: "index_calendars_on_user_id"
   end


### PR DESCRIPTION
# 部屋ごとに同google_calendar_idでも取得可能にする

- [x] 同google_calendar_idはroom_idにかかわらず弾くdb設定➡room_idが違えば、同google_calendar_idを許容する設定
```
class ChangeGoogleEventIdIndexOnCalendars < ActiveRecord::Migration[7.2]
  def change
    remove_index :calendars, name: "index_calendars_on_google_event_id"

    add_index :calendars, [:room_id, :google_event_id],
              unique: true,
              name: "index_calendars_on_room_id_and_google_event_id"
  end
end
```