### PR TITLE
add/production_g_calendar_cron

### DIFF
--- a/run_google_events.sh
+++ b/run_google_events.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 export RAILS_ENV=production
-cd /rails
+cd /online_room
 bundle exec rake google_events:delete_old >> log/cron.log 2>&1


### PR DESCRIPTION
# renderのcron jobで実行するDocker Commandsの簡略化のため、ファイル作成

```
# 
#!/bin/bash
export RAILS_ENV=production
cd /online_room
bundle exec rake google_events:delete_old >> log/cron.log 2>&1
```