### PR TITLE
Bump brakeman from 7.1.1 to 8.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.1)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
## 概要
- `bin/brakeman --ensure-latest` が「7.1.1は最新版ではない」ためCIの `scan_ruby` で失敗していたのを解消します。
- ローカル(Ruby 3.3.6)で brakeman 8.0.6 を実際にアプリへ実行して検証: エラー0件、依存も `racc`（バージョン制約なし）のみで変更なし。brakemanは開発時の静的解析ツールでありアプリの実行に影響しません。

## 注意点
- brakeman 8.x で追加された `EOLRails` チェックにより「Rails 7.2.2.1のサポートは2026-08-09に終了した」という警告が新たに出ます。これはbrakemanのバージョンとは無関係の正当な指摘のため、`scan_ruby` は別理由で引き続き赤くなる可能性があります（Railsアップグレードは #371 で見送り済み、別途対応が必要です）。

🤖 Generated with Claude Code