### PR TITLE
Bump meta-tags from 2.22.1 to 2.22.2 (minimal, replaces #367)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,8 +213,8 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
-    meta-tags (2.22.1)
-      actionpack (>= 6.0.0, < 8.1)
+    meta-tags (2.22.2)
+      actionpack (>= 6.0.0, < 8.2)
     mini_mime (1.1.5)
     minitest (5.26.0)
     msgpack (1.8.0)


### PR DESCRIPTION
## 概要
元の Dependabot PR #367 は main の進行によりロックファイルがコンフリクトし、`@dependabot recreate` を依頼したところ意図せずRailsパッチ・minitest 6系などの大規模な再解決が行われテストが壊れました。
本PRはそれを避け、meta-tagsのバージョンのみを手動で最小差分に更新したものです（`bundle lock --update meta-tags` の実際の解決結果を使用、ローカルRuby 3.3.6で検証）。

## 対応
- meta-tags 2.22.1 → 2.22.2
- actionpackの上限制約が `< 8.1` → `< 8.2` に変更（bundlerの実解決結果通り）

古い #367 はクローズしてください。