### PR TITLE
Bump turbo-rails from 2.0.17 to 2.0.20 (minimal, replaces #369)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -448,7 +448,7 @@ GEM
       actionpack (>= 7.1.0)
       railties (>= 7.1.0)
     tsort (0.2.0)
-    turbo-rails (2.0.17)
+    turbo-rails (2.0.20)
       actionpack (>= 7.1.0)
       railties (>= 7.1.0)
     tzinfo (2.0.6)


### PR DESCRIPTION
## 概要
元の Dependabot PR #369 は main の進行によりロックファイルがコンフリクトし、`@dependabot recreate` を依頼したところ意図せずRailsパッチ・minitest 6系などの大規模な再解決が行われテストが壊れました。
本PRはそれを避け、turbo-railsのバージョンのみを手動で最小差分に更新したものです（`bundle lock --update turbo-rails` の実際の解決結果を使用、ローカルRuby 3.3.6で検証）。

## 対応
- turbo-rails 2.0.17 → 2.0.20
- 依存制約（actionpack >= 7.1.0, railties >= 7.1.0）は変更なし

古い #369 はクローズしてください。