### PR TITLE
Fix diary read-count always showing 0 for newest entries

### DIFF
--- a/app/controllers/exchange_diaries_controller.rb
+++ b/app/controllers/exchange_diaries_controller.rb
@@ -86,6 +86,7 @@ class ExchangeDiariesController < ApplicationController
     other_diary_ids = @room.exchange_diaries
                            .where.not(user: current_user)
                            .includes(:reads)
+                           .order(created_at: :desc)
                            .page(params[:page])
                            .pluck(:id)
 


### PR DESCRIPTION
## 概要
交換日記の既読カウント（「読みました」）が、最新の日記だけ常に0になってしまう不具合の修正です。

## 原因
`ExchangeDiariesController#mark_unread_diaries_as_read` が既読対象の日記IDを取得する際に `.order()` を指定しておらず、一覧表示クエリ（`order(created_at: :desc)`）とページの並び順が食い違っていました。

`config/initializers/kaminari_config.rb` で `default_per_page = 2` と非常に小さく設定されているため、日記が3件以上たまると即座にページ跨ぎが発生し、以下のようなズレが生じます。

- 画面のページ1に表示される日記（新しい順）: `[3, 2]`
- 実際に既読マークされる日記（並び順指定なしのpage(1)）: `[1, 2]`

結果、同居人が最新の日記(id=3)を実際に開いて読んでも、既読マークの対象は古い方の日記になってしまい、最新の日記の「読みました」は常に0のままでした。

## 修正内容
`mark_unread_diaries_as_read` のクエリに `.order(created_at: :desc)` を追加し、一覧表示クエリと同じ並び順・ページングに揃えました（1行差分）。

## 検証
ActiveRecord + SQLiteのみを使った分離環境で、修正前は表示中の日記IDと既読マーク対象の日記IDが一致しないこと、修正後は一致することを確認済みです。