### PR TITLE
Fix password reset 500 error (devise mailer_sender placeholder)

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = ENV["GMAIL_ADDRESS"]
 
   # config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], {
   #   scope: "email,profile",


### PR DESCRIPTION
## 概要
パスワード再発行（リセット）時に「We're sorry, but something went wrong.」の500エラーが発生する不具合の修正です。

## 原因
`config/initializers/devise.rb` の `mailer_sender` がDeviseのデフォルトのプレースホルダーのまま（`please-change-me-at-config-initializers-devise@example.com`）になっていました。

本番のSMTP設定（`config/environments/production.rb`）はGmailの実アカウントで認証していますが、Gmailは認証アカウントと異なるFromアドレスでの送信を拒否します。さらに `config.action_mailer.raise_delivery_errors = true` のため、この配信エラーがそのまま例外としてリクエストをクラッシュさせ、ユーザーには500エラーが表示されていました。

## 修正内容
`mailer_sender` を、SMTP認証で既に使っている `ENV[GMAIL_ADDRESS]` を参照するように変更しました（1行差分）。メールアドレスをソースコードにハードコードしないための対応です。

## 備考
`GMAIL_ADDRESS`/`GMAIL_PASSWORD` の環境変数は確認済み（アドレス一致、パスワードはGoogleのアプリパスワードを推奨）。